### PR TITLE
Connect Loki (Archivist) and Jaeger (Senses) in Grafana

### DIFF
--- a/deploy/aura/templates/grafana-datasources.yaml
+++ b/deploy/aura/templates/grafana-datasources.yaml
@@ -29,7 +29,7 @@ data:
         jsonData:
           derivedFields:
             - datasourceUid: Jaeger
-              matcherRegex: 'trace_id[:=]\s*(\w+)'
+              matcherRegex: 'trace_id[:=]\s*([a-fA-F0-9]+)'
               name: trace_id
               url: '${__value.raw}'
               internal: true


### PR DESCRIPTION
Updated the Grafana datasources configuration to link Loki logs with Jaeger traces using a derived field. This was achieved by modifying the `matcherRegex` in the Loki datasource section of `deploy/aura/templates/grafana-datasources.yaml`.

---
*PR created automatically by Jules for task [13875349241892433579](https://jules.google.com/task/13875349241892433579) started by @zaebee*