### PR TITLE
fix(docker): align proto stub paths with buf.gen.yaml output

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -60,8 +60,9 @@ jobs:
                   name: proto-stubs
                   path: |
                       packages/aura-core/src/aura_core/gen
-                      core/src/hive/proto
-                      api-gateway/src/proto
+                      core/gen-proto
+                      api-gateway/gen-proto
+                      synapses/telegram-bot/gen-proto
                       frontend/src/lib/aura
 
     quality:

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -25,14 +25,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && \
 # Copy virtual environment from builder (workspace root .venv)
 COPY --from=builder /app/.venv /app/.venv
 
-# Copy source code to the same relative path as builder
+# Copy source code and generated proto stubs
 COPY api-gateway/src /app/api-gateway/src
+COPY api-gateway/gen-proto /app/api-gateway/gen-proto
 
 WORKDIR /app/api-gateway
 
 # Set PATH to use the virtual environment
 ENV PATH="/app/.venv/bin:$PATH"
-ENV PYTHONPATH=/app/api-gateway/src:/app/api-gateway/src/proto
+ENV PYTHONPATH=/app/api-gateway/src:/app/api-gateway/gen-proto
 
 EXPOSE 8000
 

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -31,8 +31,9 @@ COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 # Copy virtual environment from builder (workspace root .venv)
 COPY --from=builder /app/.venv /app/.venv
 
-# Copy source code and other artifacts to the same relative path as builder
+# Copy source code, generated proto stubs and other artifacts
 COPY core/src /app/core/src
+COPY core/gen-proto /app/core/gen-proto
 COPY core/alembic.ini /app/core/alembic.ini
 COPY core/migrations /app/core/migrations
 COPY core/data /app/core/data
@@ -42,7 +43,7 @@ WORKDIR /app/core
 
 # Set PATH to use the virtual environment
 ENV PATH="/app/.venv/bin:$PATH"
-ENV PYTHONPATH=/app/core:/app/core/src:/app/core/src/hive/proto
+ENV PYTHONPATH=/app/core:/app/core/src:/app/core/gen-proto
 
 # Verify critical packages installed
 RUN python -c "import grpc_health.v1.health_pb2"


### PR DESCRIPTION
## Summary

Fixes #143 — `ModuleNotFoundError: No module named 'aura'` on api-gateway startup in k8s.

**Root cause:** `buf generate` outputs gRPC stubs to `*/gen-proto/` directories, but Dockerfiles and CI referenced stale/non-existent paths (`api-gateway/src/proto`, `core/src/hive/proto`). Proto stubs were never copied into the container images.

**Changes:**
- **api-gateway/Dockerfile** — add `COPY api-gateway/gen-proto`, fix `PYTHONPATH` from `src/proto` to `gen-proto`
- **core/Dockerfile** — add `COPY core/gen-proto`, fix `PYTHONPATH` from `src/hive/proto` to `gen-proto`
- **ci-cd.yaml** — fix artifact upload paths to match actual `buf.gen.yaml` output directories; add missing `synapses/telegram-bot/gen-proto`

All paths now consistent with `buf.gen.yaml` and `Makefile` (`GATEWAY_PATH`, `CORE_PATH`).

## Test plan

- [ ] Run `make generate && make build` locally — verify docker images build without errors
- [ ] `docker run` the gateway image — confirm `from aura.negotiation.v1 import ...` resolves
- [ ] Deploy to k8s — verify `kubectl logs -l app=gateway` shows clean startup
- [ ] Verify core service also starts cleanly with proto imports


Made with [Cursor](https://cursor.com)