### PR TITLE
ci(security): least-privilege permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -20,9 +20,16 @@ env:
     REGISTRY: ghcr.io
     IMAGE_NAME: ${{ github.repository }}
 
+# Least-privilege default for all jobs; jobs that need more override below.
+permissions:
+    contents: read
+
 jobs:
     check-changes:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: read # dorny/paths-filter reads changed files on PRs
         outputs:
             code: ${{ steps.filter.outputs.code }}
             infra: ${{ steps.filter.outputs.infra }}

--- a/.github/workflows/distill-knowledge.yml
+++ b/.github/workflows/distill-knowledge.yml
@@ -20,10 +20,17 @@ on:
       - 'tools/validate_knowledge.py'
       - 'docs/ARCHITECTURAL_ANCHOR.md'
 
+# Least-privilege default for all jobs; jobs that need more override below.
+permissions:
+  contents: read
+
 jobs:
   distill-and-validate:
     name: Extract and Validate Architecture
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # posts a failure comment on the PR
 
     steps:
       - name: Checkout code
@@ -124,6 +131,8 @@ jobs:
   attach-to-release:
     name: Attach to Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # softprops/action-gh-release creates/updates a release
     needs: distill-and-validate
     if: startsWith(github.ref, 'refs/tags/')
 


### PR DESCRIPTION
## Summary
Resolves all **6 CodeQL code-scanning alerts** (`actions/missing-workflow-permissions`, medium). Without an explicit `permissions:` block, `GITHUB_TOKEN` inherits broad default scopes — this applies least-privilege.

## Changes
Both workflows get a top-level `contents: read` baseline, with per-job overrides only where a job genuinely needs more:

**`.github/workflows/ci-cd.yaml`** (alerts on jobs at L25/48/69/188)
- top-level `contents: read` → covers `prepare`, `quality`, `deploy`
- `check-changes`: `+ pull-requests: read` (dorny/paths-filter lists changed files on PRs)
- `build-and-push`: unchanged (already `contents: read` + `packages: write`)

**`.github/workflows/distill-knowledge.yml`** (alerts on jobs at L25/125)
- top-level `contents: read`
- `distill-and-validate`: `+ pull-requests: write` (github-script posts a failure comment on PRs)
- `attach-to-release`: `contents: write` (softprops/action-gh-release creates a release)

## Verification
- Both files parse as valid YAML; every job now has explicit or inherited permissions.
- No `run:` steps were changed; no untrusted-input interpolation introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)