### PR TITLE
chore(security): bump setuptools 80.10.1 -> 83.0.0 (GHSA-h35f-9h28-mq5c)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3659,11 +3659,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.10.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/ff/f75651350db3cf2ef767371307eb163f3cc1ac03e16fdf3ac347607f7edb/setuptools-80.10.1.tar.gz", hash = "sha256:bf2e513eb8144c3298a3bd28ab1a5edb739131ec5c22e045ff93cd7f5319703a", size = 1229650, upload-time = "2026-01-21T09:42:03.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/76/f963c61683a39084aa575f98089253e1e852a4417cb8a3a8a422923a5246/setuptools-80.10.1-py3-none-any.whl", hash = "sha256:fc30c51cbcb8199a219c12cc9c281b5925a4978d212f84229c909636d9f6984e", size = 1099859, upload-time = "2026-01-21T09:42:00.688Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Closes the one remaining Dependabot alert (#324, medium) — a **freshly disclosed** advisory (GHSA-h35f-9h28-mq5c, published 2026-07-23): setuptools `MANIFEST.in` exclusion bypass in sdist via Unicode NFC/NFD collision on macOS APFS/HFS+.

- `setuptools` 80.10.1 → **83.0.0** (`< 83.0.0` vulnerable, patched in 83.0.0)
- Transitive build-time dep (grpcio-tools, torch); low practical risk for this Linux/Docker pipeline (we build wheels, not sdists on macOS) — closed for hygiene.
- Lock-only change; `uv lock --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)