### PR TITLE
fix(api-gateway): repair vision test + add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  # Python dependencies — single uv workspace lock at the repo root.
+  # (Member uv.lock files were removed; only the root lock is authoritative.)
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      # Collapse routine minor/patch bumps into a single weekly PR so the
+      # alert backlog can't pile up again. Major bumps are intentionally
+      # left ungrouped — each lands as its own PR for isolated review.
+      python-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      # Group security fixes together so they are easy to spot and merge.
+      python-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # GitHub Actions — keep workflow action pins current and least-surprising.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,8 @@ setup-hooks:
 test: $(PROTO_SENTINEL)
 	# Run core tests
 	PYTHONPATH=$(CORE_PATH) uv run pytest core/tests/ -v
+	# Run api-gateway tests (env is provided by api-gateway/tests/conftest.py)
+	PYTHONPATH=$(GATEWAY_PATH) uv run pytest api-gateway/tests/ -v
 	# Run telegram-bot tests with isolated path to avoid 'src' collision
 	PYTHONPATH=$(TG_PATH) uv run pytest synapses/telegram-bot/tests/ -v
 	# Run mcp-server tests if they exist

--- a/api-gateway/tests/conftest.py
+++ b/api-gateway/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Test configuration for the api-gateway.
+
+The gateway's ``Settings`` (env_prefix ``AURA_GATEWAY__``) requires
+``core_service_host`` and ``redis_url`` at import time. Provide dummy values so
+the suite is self-contained and does not depend on the ambient environment.
+``setdefault`` keeps any real values a developer/CI already exported.
+"""
+
+import os
+
+os.environ.setdefault("AURA_GATEWAY__CORE_SERVICE_HOST", "localhost")
+os.environ.setdefault("AURA_GATEWAY__REDIS_URL", "redis://localhost:6379")

--- a/api-gateway/tests/test_vision.py
+++ b/api-gateway/tests/test_vision.py
@@ -3,9 +3,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import nats
 import pytest
+from aura_core_gen.aura.core.v1 import Signal
 from fastapi.testclient import TestClient
 from main import app
-from security import verify_signature
+from security import verify_public_membrane
 
 
 @pytest.fixture
@@ -26,7 +27,7 @@ async def test_analyze_vision_endpoint():
     app.state.nc = mock_nc
 
     # We override the dependency to skip signature verification for this test
-    app.dependency_overrides[verify_signature] = lambda: "did:key:test"
+    app.dependency_overrides[verify_public_membrane] = lambda: "did:key:test"
 
     client = TestClient(app)
 
@@ -59,13 +60,14 @@ async def test_analyze_vision_endpoint():
     # Verify NATS request was called
     mock_nc.request.assert_called_once()
     args, kwargs = mock_nc.request.call_args
-    # Subject should match settings default or be passed as param (we use default)
+    # Subject should match the configured vision subject
     assert args[0] == "aura.worker.v1.vision.analyze"
 
-    payload = json.loads(args[1].decode())
-    assert "images" in payload
-    assert len(payload["images"]) == 2
-    assert payload["prompt"] == "car search"
+    # The gateway serializes a protobuf Signal (not JSON) onto the wire.
+    signal = Signal().parse(args[1])
+    assert len(signal.perception.image_data) == 2
+    assert signal.perception.prompt == "car search"
+    assert signal.perception.agent.did == "did:key:test"
 
     # Cleanup
     app.dependency_overrides = {}


### PR DESCRIPTION
Two post-security-cleanup follow-ups.

## 1. Repair & wire up the api-gateway vision test
`api-gateway/tests/test_vision.py` had silently drifted from the code **and was never run by CI**:
- Overrode the removed `verify_signature` dependency instead of the current `verify_public_membrane` → auth ran for real → 401.
- Asserted a JSON request payload, but the endpoint now serializes a protobuf `Signal` onto the NATS wire.
- `make test` never invoked api-gateway tests — the `GATEWAY_PATH` var existed but was unused.

Fixes:
- Override the correct dependency; parse & assert the protobuf `Signal` (image count, prompt, agent DID).
- New `api-gateway/tests/conftest.py` supplies the required `AURA_GATEWAY__*` settings → suite is self-contained.
- Wire `api-gateway/tests/` into the `make test` target via the existing `GATEWAY_PATH`.

**Verified:** `make test` now green across **core (114), api-gateway (1), telegram-bot (6)**.

## 2. Add `.github/dependabot.yml`
Keeps the alert backlog from piling up again (this repo had reached 310 open alerts):
- Weekly updates for the **uv** workspace (single root lock) and **github-actions**.
- Routine **minor/patch grouped** into one PR; **security fixes grouped** separately; **major bumps ungrouped** so each breaking change gets its own reviewable PR — mirroring the wave approach used to clear the backlog.

Note: a benign `StarletteDeprecationWarning` (httpx → httpx2 for TestClient) remains under starlette 1.x; the test passes with httpx. Adding `httpx2` to silence it can be a later cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)