### PR TITLE
fix(mcp-server): declare hatch wheel target so aura-mcp builds

### DIFF
--- a/synapses/mcp-server/pyproject.toml
+++ b/synapses/mcp-server/pyproject.toml
@@ -30,6 +30,15 @@ core = { workspace = true }
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# The service uses a flat src/ layout (top-level modules: main, receptor,
+# translator, effector) rather than a src/<package> dir, so hatchling cannot
+# auto-detect what to ship. Point it at src/ and strip the prefix so the
+# modules install as top-level (matching how they are imported and the
+# `aura-mcp = "main:main"` entry point).
+[tool.hatch.build.targets.wheel]
+only-include = ["src"]
+sources = ["src"]
+
 [tool.ruff]
 target-version = "py312"
 line-length = 88


### PR DESCRIPTION
## Problem
`uv sync --package aura-mcp` failed:
```
hatchling ... ValueError: Unable to determine which files to ship
```
The service uses a **flat `src/` layout** (top-level modules `main`, `receptor`, `translator`, `effector`) rather than a `src/<package>/` dir, so hatchling couldn't auto-detect the wheel contents. It only bites `aura-mcp` because it declares `[project.scripts] aura-mcp = "main:main"`, which forces uv to build the wheel — sibling app-members either declare no scripts (uv never builds them: core, api-gateway, telegram-bot) or ship a package dir (`bee-keeper`'s `src/hive`).

## Fix
Point the wheel target at `src/` and strip the prefix so the modules install as the top-level names they're imported by and that the entry point references:
```toml
[tool.hatch.build.targets.wheel]
only-include = ["src"]
sources = ["src"]
```

## Verified
- `uv sync --package aura-mcp` now **builds and installs** (no hatchling error).
- mcp-server still imports/runs via its `PYTHONPATH` (`main.mcp` → FastMCP "Aura").
- Whole-workspace `uv sync` unaffected.

## Note (pre-existing, out of scope)
The flat-`src` convention means several members expose generic top-level modules (`main`, `config`) when installed editable, so the `aura-mcp`/`aura-keeper` console scripts are ambiguous in a shared venv. This doesn't affect runtime (services run via isolated `PYTHONPATH`). A proper fix would move each app under its own package namespace (`src/aura_mcp/…`) — a larger refactor left for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)