### PR TITLE
test(mcp-server): add test suite (translator, receptor, effector)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,14 @@ test: $(PROTO_SENTINEL)
 	PYTHONPATH=$(GATEWAY_PATH) uv run pytest api-gateway/tests/ -v
 	# Run telegram-bot tests with isolated path to avoid 'src' collision
 	PYTHONPATH=$(TG_PATH) uv run pytest synapses/telegram-bot/tests/ -v
-	# Run mcp-server tests if they exist
-	if [ -d "synapses/mcp-server/tests" ]; then PYTHONPATH=$(MCP_PATH):$(CORE_PATH) uv run pytest synapses/mcp-server/tests/ -v; fi
+	# Run mcp-server tests if they exist.
+	# aura-mcp's runtime deps (fastmcp) aren't in the root dev group, so add them
+	# additively (--inexact keeps the already-synced dev deps, avoids aura-worker's
+	# heavy torch stack); --no-sync stops `uv run` from reverting that.
+	if [ -d "synapses/mcp-server/tests" ]; then \
+		uv sync --package aura-mcp --inexact; \
+		PYTHONPATH=$(MCP_PATH):$(CORE_PATH) uv run --no-sync pytest synapses/mcp-server/tests/ -v; \
+	fi
 
 # Run tests with coverage report
 test-cov:

--- a/synapses/mcp-server/tests/test_effector.py
+++ b/synapses/mcp-server/tests/test_effector.py
@@ -1,0 +1,30 @@
+"""Tests for MCPEffector — background hive-event handling."""
+
+from types import SimpleNamespace
+
+import pytest
+from aura_core_gen.aura.core.v1 import Event
+
+from effector import MCPEffector
+from translator import MCPTranslator
+
+
+@pytest.mark.asyncio
+async def test_run_without_nats_client_returns_early():
+    # No NATS client -> should log a warning and return without raising.
+    await MCPEffector(nats_client=None).run()
+
+
+@pytest.mark.asyncio
+async def test_process_event_parses_valid_proto():
+    event = Event(topic="aura.hive.events.negotiation")
+    msg = SimpleNamespace(data=bytes(event), subject="aura.hive.events.negotiation")
+    # Should parse and log without raising.
+    await MCPEffector(translator=MCPTranslator())._process_event(msg)
+
+
+@pytest.mark.asyncio
+async def test_process_event_swallows_malformed_data():
+    # Undecodable payload must be caught, not propagated (background worker).
+    msg = SimpleNamespace(data=b"\xff\xffnot-a-proto", subject="aura.hive.events.x")
+    await MCPEffector(translator=MCPTranslator())._process_event(msg)

--- a/synapses/mcp-server/tests/test_receptor.py
+++ b/synapses/mcp-server/tests/test_receptor.py
@@ -1,0 +1,75 @@
+"""Integration tests for MCPReceptor — tool registration and wiring.
+
+Uses FastMCP's in-memory Client to invoke the registered tools, with a mocked
+MetabolicLoop so no live Hive is required.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from aura_core_gen.aura.core.v1 import (
+    NegotiationObservation,
+    Observation,
+    OfferAccepted,
+    SignalType,
+)
+from fastmcp import Client, FastMCP
+
+from receptor import MCPReceptor
+from translator import MCPTranslator
+
+
+def _make_receptor(observation: Observation):
+    """Wire a FastMCP + real translator + a metabolism stub returning `observation`."""
+    mcp = FastMCP(name="test-hive")
+    metabolism = AsyncMock()
+    metabolism.execute = AsyncMock(return_value=observation)
+    MCPReceptor(mcp, metabolism, MCPTranslator())
+    return mcp, metabolism
+
+
+@pytest.mark.asyncio
+async def test_tools_are_registered():
+    mcp, _ = _make_receptor(Observation(success=True))
+    async with Client(mcp) as client:
+        names = {t.name for t in await client.list_tools()}
+    assert {"search_hotels", "negotiate_price"} <= names
+
+
+@pytest.mark.asyncio
+async def test_negotiate_price_delegates_and_formats():
+    obs = Observation(
+        success=True,
+        negotiation=NegotiationObservation(accepted=OfferAccepted(final_price=42.0)),
+    )
+    mcp, metabolism = _make_receptor(obs)
+
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "negotiate_price", {"item_id": "room-1", "bid": 50.0}
+        )
+
+    assert result.data == "🎉 SUCCESS! Negotiation accepted at $42.00."
+    metabolism.execute.assert_awaited_once()
+    signal = metabolism.execute.await_args.args[0]
+    assert signal.signal_type == SignalType.SIGNAL_TYPE_NEGOTIATION
+    assert signal.negotiation.item_identifier == "room-1"
+    assert signal.negotiation.bid_amount == 50.0
+
+
+@pytest.mark.asyncio
+async def test_search_hotels_delegates_search_signal():
+    mcp, metabolism = _make_receptor(Observation(success=True))
+
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "search_hotels", {"query": "sea view", "limit": 2}
+        )
+
+    assert "no negotiation data" in result.data
+    metabolism.execute.assert_awaited_once()
+    signal = metabolism.execute.await_args.args[0]
+    assert signal.signal_type == SignalType.SIGNAL_TYPE_UNSPECIFIED
+    meta = signal.metadata.to_dict()
+    assert meta["query"] == "sea view"
+    assert meta["intent"] == "search"

--- a/synapses/mcp-server/tests/test_translator.py
+++ b/synapses/mcp-server/tests/test_translator.py
@@ -1,0 +1,89 @@
+"""Unit tests for MCPTranslator — the pure Signal/Observation transforms."""
+
+from aura_core_gen.aura.core.v1 import (
+    NegotiationObservation,
+    Observation,
+    OfferAccepted,
+    OfferCountered,
+    OfferRejected,
+    SignalType,
+)
+
+from translator import MCPTranslator
+
+
+def _struct_to_dict(struct):
+    return struct.to_dict() if hasattr(struct, "to_dict") else dict(struct)
+
+
+# --- to_signal -------------------------------------------------------------
+
+
+def test_to_signal_negotiate_builds_negotiation_signal():
+    sig = MCPTranslator().to_signal("negotiate", item_id="hotel-42", bid=99.5)
+    assert sig.signal_type == SignalType.SIGNAL_TYPE_NEGOTIATION
+    assert sig.negotiation.item_identifier == "hotel-42"
+    assert sig.negotiation.bid_amount == 99.5
+    assert sig.negotiation.agent.did == "mcp-agent"
+    assert sig.identifier  # a uuid was assigned
+
+
+def test_to_signal_search_encodes_query_metadata():
+    sig = MCPTranslator().to_signal("search", query="beach hotels", limit=5)
+    assert sig.signal_type == SignalType.SIGNAL_TYPE_UNSPECIFIED
+    meta = _struct_to_dict(sig.metadata)
+    assert meta["query"] == "beach hotels"
+    assert meta["limit"] == "5"
+    assert meta["intent"] == "search"
+
+
+def test_to_signal_unknown_tool_returns_unspecified():
+    sig = MCPTranslator().to_signal("frobnicate")
+    assert sig.signal_type == SignalType.SIGNAL_TYPE_UNSPECIFIED
+    assert sig.identifier
+
+
+# --- from_observation ------------------------------------------------------
+
+
+def test_from_observation_failure_reports_error():
+    obs = Observation(success=False, error="boom")
+    assert MCPTranslator().from_observation(obs) == "❌ Operation failed: boom"
+
+
+def test_from_observation_success_without_negotiation():
+    obs = Observation(success=True)
+    assert "no negotiation data" in MCPTranslator().from_observation(obs)
+
+
+def test_from_observation_accepted():
+    obs = Observation(
+        success=True,
+        negotiation=NegotiationObservation(accepted=OfferAccepted(final_price=123.45)),
+    )
+    assert (
+        MCPTranslator().from_observation(obs)
+        == "🎉 SUCCESS! Negotiation accepted at $123.45."
+    )
+
+
+def test_from_observation_countered():
+    obs = Observation(
+        success=True,
+        negotiation=NegotiationObservation(
+            countered=OfferCountered(proposed_price=80.0, human_message="too low")
+        ),
+    )
+    result = MCPTranslator().from_observation(obs)
+    assert "COUNTER-OFFER: $80.00" in result
+    assert "too low" in result
+
+
+def test_from_observation_rejected():
+    obs = Observation(
+        success=True,
+        negotiation=NegotiationObservation(
+            rejected=OfferRejected(reason_code="NO_INVENTORY")
+        ),
+    )
+    assert MCPTranslator().from_observation(obs) == "🚫 REJECTED. Reason: NO_INVENTORY"


### PR DESCRIPTION
## Summary
mcp-server had **no tests** — the fastmcp 3.x migration (#215/#221) was only covered by an import smoke check. Adds a **14-test** suite and wires it into `make test`.

## Tests
- **`test_translator.py`** (8) — `MCPTranslator.to_signal` (negotiate / search / unknown) and `from_observation` (failure / no-negotiation / accepted / countered / rejected). Pure protobuf transforms, no mocks.
- **`test_receptor.py`** (3) — registers `MCPReceptor` on a real `FastMCP` with a mocked `MetabolicLoop` and drives the tools through fastmcp's **in-memory `Client`**, asserting `search_hotels`/`negotiate_price` build the right `Signal` and format the `Observation` (real fastmcp 3.x tool round-trip).
- **`test_effector.py`** (3) — `_process_event` parses a valid proto and swallows malformed payloads; `run()` returns early without a NATS client.

## Test wiring
aura-mcp's runtime deps (`fastmcp`) aren't in the root dev group, so `make test` adds them additively:
```make
uv sync --package aura-mcp --inexact   # keeps dev deps, skips aura-worker's heavy torch stack
PYTHONPATH=$(MCP_PATH):$(CORE_PATH) uv run --no-sync pytest synapses/mcp-server/tests/ -v
```
`--inexact` preserves the already-synced dev deps; `--no-sync` stops `uv run` from reverting the fastmcp install.

## Verified
`make test` green end-to-end: **core 114, api-gateway 1, telegram-bot 6, mcp-server 14**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)