### PR TITLE
ci(frontend): pin bun version + frozen lockfile to fix flaky builds

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,9 @@
 # Stage 1: Build static assets
-FROM oven/bun:1.1-alpine AS builder
+# Pin a full bun patch (not the floating 1.1 tag): the repo's bun.lock uses the
+# text format (lockfileVersion 1) written by bun 1.3.x, which older 1.1.x patches
+# fail to parse ("Unknown lockfile version"). Keep this aligned with the bun used
+# to author the lockfile.
+FROM oven/bun:1.3.14-alpine AS builder
 
 WORKDIR /app
 
@@ -15,7 +19,7 @@ COPY proto ./proto
 
 # Copy lockfile and package.json from the frontend directory
 COPY frontend/package.json frontend/bun.lock ./frontend/
-RUN cd frontend && bun install
+RUN cd frontend && bun install --frozen-lockfile
 
 # Copy configuration files
 COPY frontend/tsconfig.json frontend/tsconfig.app.json frontend/tsconfig.node.json ./frontend/


### PR DESCRIPTION
## Problem
The frontend Docker build intermittently failed with:
```
error: Unknown lockfile version
InvalidLockfileVersion: failed to parse lockfile: 'bun.lock'
```
(seen on #221 CI — passed only on retry). Root cause: the Dockerfile used the **floating `oven/bun:1.1-alpine`** tag, but `frontend/bun.lock` is the **text format** (`lockfileVersion: 1`) authored by **bun 1.3.x**. Older 1.1.x patches can't parse it, so whenever the runner resolved/cached an older 1.1 image the build broke.

## Fix
- Pin **`oven/bun:1.3.14-alpine`** (full patch) — matches the bun that authored the lockfile; deterministic, no floating-tag drift.
- `bun install --frozen-lockfile` — reproducible installs; fails loudly on drift instead of silently regenerating.

## Verified
- `docker build --target builder -f frontend/Dockerfile .` succeeds end-to-end: bun 1.3.14 frozen install (221 packages) + vite 7 production build, **no lockfile error**.
- `bun install --frozen-lockfile --dry-run` confirms `bun.lock` is in sync with `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)