### PR TITLE
fix(aura-core): downgrade optional hive-manifest not-found log to debug

### DIFF
--- a/packages/aura-core/src/aura_core/manifest.py
+++ b/packages/aura-core/src/aura_core/manifest.py
@@ -41,7 +41,10 @@ def _load_manifest() -> dict[str, Any]:
     manifest_path = root / "hive-manifest.yaml"
 
     if not manifest_path.exists():
-        logger.warning("hive-manifest.yaml not found at %s, using defaults", root)
+        # Optional config: absence is normal (e.g. standalone container runs
+        # without the k8s configmap mount). Genuine problems — a manifest that
+        # exists but is empty/malformed — still warn below.
+        logger.debug("hive-manifest.yaml not found at %s, using defaults", root)
         return _DEFAULT_MANIFEST
 
     try:


### PR DESCRIPTION
## Problem
Every service logged `hive-manifest.yaml not found at <dir>, using defaults` at startup (seen in `docker run` of core and telegram-bot).

## Root cause (systematic investigation)
- `hive-manifest.yaml` is an **optional** geography config. It exists at the repo root and is mounted into pods via configmap at `/app/hive-manifest.yaml` (`values.yaml` `hiveManifest.mountPath` + `telegram-deployment.yaml` subPath), where `find_hive_root()` locates it — **so production is fine**.
- `aura_core/manifest.py` loads it **eagerly at import** (`MACRO_ATCG_FOLDERS = get_macro_atcg_folders()`), so the log fires on every service's startup even though only **bee-keeper**'s audit consumes the geography data.
- The warning therefore only appears in standalone container runs (no configmap) and is pure noise there — not a functional bug.

## Fix
Log the not-found fallback at `debug` (it's expected, graceful behavior). The empty/invalid/parse-error cases for an *existing* manifest still `warning`.

## Verified
- No test asserts on this log; `aura_core` imports clean; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)