### PR TITLE
refactor(persistence): extract DealRepository from the PersistenceSkill god-protein

### DIFF
--- a/core/src/aura_hive/hive/proteins/persistence/deals.py
+++ b/core/src/aura_hive/hive/proteins/persistence/deals.py
@@ -1,0 +1,66 @@
+"""DealRepository — locked-deal persistence, split out of PersistenceSkill.
+
+Keeps the deal SQL in one place so the skill's handlers stay thin
+(params -> repo -> Observation). Methods are synchronous; callers wrap them in
+``asyncio.to_thread`` exactly as the inline closures did before.
+"""
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from .engine import DealStatus, LockedDeal
+from .schema import DealSchema
+
+
+class DealRepository:
+    """CRUD for LockedDeal rows over a session factory (`_get_session`)."""
+
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        self._session = session_factory
+
+    def create(self, params: dict[str, Any]) -> None:
+        with self._session() as session:
+            deal = LockedDeal(
+                id=params["id"],
+                item_id=params["item_id"],
+                item_name=params["item_name"],
+                final_price=params["final_price"],
+                currency=params["currency"],
+                payment_memo=params["payment_memo"],
+                secret_content=params["secret_content"],
+                status=DealStatus.PENDING,
+                buyer_did=params.get("buyer_did"),
+                expires_at=params["expires_at"],
+            )
+            session.add(deal)
+            session.commit()
+
+    def get_by_id(self, deal_id: str) -> dict[str, Any] | None:
+        with self._session() as session:
+            deal = session.query(LockedDeal).filter_by(id=deal_id).first()
+            return DealSchema.model_validate(deal).model_dump() if deal else None
+
+    def get_by_memo(self, memo: str) -> dict[str, Any] | None:
+        with self._session() as session:
+            deal = session.query(LockedDeal).filter_by(payment_memo=memo).first()
+            return DealSchema.model_validate(deal).model_dump() if deal else None
+
+    def update_status(self, deal_id: str, status: str, params: dict[str, Any]) -> bool:
+        with self._session() as session:
+            deal = session.query(LockedDeal).filter_by(id=deal_id).first()
+            if not deal:
+                return False
+
+            deal.status = DealStatus(status)
+            if status == "PAID":
+                deal.transaction_hash = params.get("transaction_hash")
+                deal.block_number = params.get("block_number")
+                deal.from_address = params.get("from_address")
+                deal.paid_at = params.get("paid_at", datetime.now(UTC))
+
+            deal.updated_at = datetime.now(UTC)
+            session.commit()
+            return True

--- a/core/src/aura_hive/hive/proteins/persistence/skill.py
+++ b/core/src/aura_hive/hive/proteins/persistence/skill.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any, cast
 
 import redis.asyncio as redis
@@ -12,16 +12,15 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from aura_hive.config.database import DatabaseSettings
 
+from .deals import DealRepository
 from .engine import (
     Base,
-    DealStatus,
     InventoryItem,
-    LockedDeal,
     MetabolicCost,
     RedisCache,
     SanctifiedWallet,
 )
-from .schema import DealSchema, ItemSchema
+from .schema import ItemSchema
 from .tissue import ASSET_ENZYMES
 
 logger = structlog.get_logger(__name__)
@@ -67,6 +66,10 @@ class PersistenceSkill(
         # Asset enzymes: domain-to-enzyme mapping for "tissue specificity"
         # (defined in tissue.py so this persistence enzyme stays domain-agnostic).
         self._ASSET_ENZYMES = ASSET_ENZYMES
+
+        # Deal SQL lives in DealRepository; the _get_session reference is bound
+        # lazily and only invoked at operation time (after bind()).
+        self._deals = DealRepository(self._get_session)
 
     def get_name(self) -> str:
         return "persistence"
@@ -234,26 +237,7 @@ class PersistenceSkill(
 
     async def _create_deal(self, params: dict[str, Any]) -> Observation:
         try:
-
-            def create() -> bool:
-                with self._get_session() as session:
-                    deal = LockedDeal(
-                        id=params["id"],
-                        item_id=params["item_id"],
-                        item_name=params["item_name"],
-                        final_price=params["final_price"],
-                        currency=params["currency"],
-                        payment_memo=params["payment_memo"],
-                        secret_content=params["secret_content"],
-                        status=DealStatus.PENDING,
-                        buyer_did=params.get("buyer_did"),
-                        expires_at=params["expires_at"],
-                    )
-                    session.add(deal)
-                    session.commit()
-                    return True
-
-            await asyncio.to_thread(create)
+            await asyncio.to_thread(self._deals.create, params)
             return Observation(success=True)
         except Exception as e:
             return Observation(success=False, error=str(e))
@@ -262,15 +246,7 @@ class PersistenceSkill(
         deal_id = params.get("deal_id")
         if not deal_id:
             return Observation(success=False, error="deal_id_required")
-
-        def fetch() -> dict[str, Any] | None:
-            with self._get_session() as session:
-                deal = session.query(LockedDeal).filter_by(id=deal_id).first()
-                if deal:
-                    return DealSchema.model_validate(deal).model_dump()
-                return None
-
-        result = await asyncio.to_thread(fetch)
+        result = await asyncio.to_thread(self._deals.get_by_id, deal_id)
         if result:
             return Observation(success=True, metadata=make_struct(result))
         return Observation(success=False, error="deal_not_found")
@@ -279,15 +255,7 @@ class PersistenceSkill(
         memo = params.get("memo")
         if not memo:
             return Observation(success=False, error="memo_required")
-
-        def fetch() -> dict[str, Any] | None:
-            with self._get_session() as session:
-                deal = session.query(LockedDeal).filter_by(payment_memo=memo).first()
-                if deal:
-                    return DealSchema.model_validate(deal).model_dump()
-                return None
-
-        result = await asyncio.to_thread(fetch)
+        result = await asyncio.to_thread(self._deals.get_by_memo, memo)
         if result:
             return Observation(success=True, metadata=make_struct(result))
         return Observation(success=False, error="deal_not_found")
@@ -295,27 +263,12 @@ class PersistenceSkill(
     async def _update_deal_status(self, params: dict[str, Any]) -> Observation:
         deal_id = params.get("deal_id")
         status = params.get("status")
-
+        if not deal_id or not status:
+            return Observation(success=False, error="deal_id_and_status_required")
         try:
-
-            def update() -> bool:
-                with self._get_session() as session:
-                    deal = session.query(LockedDeal).filter_by(id=deal_id).first()
-                    if not deal:
-                        return False
-
-                    deal.status = DealStatus(status)
-                    if status == "PAID":
-                        deal.transaction_hash = params.get("transaction_hash")
-                        deal.block_number = params.get("block_number")
-                        deal.from_address = params.get("from_address")
-                        deal.paid_at = params.get("paid_at", datetime.now(UTC))
-
-                    deal.updated_at = datetime.now(UTC)
-                    session.commit()
-                    return True
-
-            success = await asyncio.to_thread(update)
+            success = await asyncio.to_thread(
+                self._deals.update_status, deal_id, status, params
+            )
             return Observation(success=success)
         except Exception as e:
             return Observation(success=False, error=str(e))


### PR DESCRIPTION
## Summary
Second slice of the god-protein cleanup (#5). The four deal handlers (`_create_deal`, `_get_deal_by_id_handler`, `_get_deal_by_memo_handler`, `_update_deal_status`) each inlined a session closure — mixing handler concerns (param parsing, threading, `Observation` building) with raw `LockedDeal` SQL.

## Change
- New `persistence/deals.py::DealRepository` — `create / get_by_id / get_by_memo / update_status` over the `_get_session` factory (synchronous; callers wrap in `to_thread` as before).
- `PersistenceSkill` handlers become **thin**: parse params → `await asyncio.to_thread(self._deals.<op>, …)` → `Observation`.
- Drops now-unused `LockedDeal / DealStatus / DealSchema / UTC` imports.
- `_update_deal_status` now guards missing `deal_id`/`status` (previously passed `None` through to a no-match) — type-safe (mypy drove this) and more informative.

## Verified
- `make test` green — 188 total (core 114, api-gateway 1, telegram-bot 6, mcp-server 14, aura-worker 53).
- `make lint` clean (mypy caught the `Any | None → str` and drove the guard).

## Note
The deal ops still run via `asyncio.to_thread` because the persistence layer uses **synchronous SQLAlchemy**. Fully removing `to_thread` means migrating to async SQLAlchemy (AsyncSession + async driver) — a separate, larger effort, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)