### PR TITLE
refactor(persistence): extract WalletRepository from god-protein

### DIFF
--- a/core/src/aura_hive/hive/proteins/persistence/skill.py
+++ b/core/src/aura_hive/hive/proteins/persistence/skill.py
@@ -18,9 +18,9 @@ from .engine import (
     InventoryItem,
     MetabolicCost,
     RedisCache,
-    SanctifiedWallet,
 )
 from .items import ItemRepository
+from .wallet import WalletRepository
 
 logger = structlog.get_logger(__name__)
 
@@ -66,6 +66,7 @@ class PersistenceSkill(
         # is bound lazily and only invoked at operation time (after bind()).
         self._deals = DealRepository(self._get_session)
         self._items = ItemRepository(self._get_session)
+        self._wallets = WalletRepository(self._get_session)
 
     def get_name(self) -> str:
         return "persistence"
@@ -277,39 +278,14 @@ class PersistenceSkill(
         if not wallet_address:
             return Observation(success=False, error="wallet_address_required")
         asset_domain = params.get("asset_domain", "")
-
-        def upsert() -> None:
-            with self._get_session() as session:
-                existing = (
-                    session.query(SanctifiedWallet)
-                    .filter_by(wallet_address=wallet_address)
-                    .first()
-                )
-                if not existing:
-                    session.add(
-                        SanctifiedWallet(
-                            wallet_address=wallet_address,
-                            asset_domain=asset_domain,
-                        )
-                    )
-                session.commit()
-
-        await asyncio.to_thread(upsert)
+        await asyncio.to_thread(self._wallets.sanctify, wallet_address, asset_domain)
         return Observation(success=True)
 
     async def _is_wallet_sanctified(self, params: dict[str, Any]) -> Observation:
         wallet_address = params.get("wallet_address")
-
-        def check() -> bool:
-            with self._get_session() as session:
-                return (
-                    session.query(SanctifiedWallet)
-                    .filter_by(wallet_address=wallet_address)
-                    .first()
-                    is not None
-                )
-
-        sanctified = await asyncio.to_thread(check)
+        sanctified = await asyncio.to_thread(
+            self._wallets.is_sanctified, wallet_address
+        )
         return Observation(
             success=True,
             metadata=make_struct({"sanctified": sanctified}),

--- a/core/src/aura_hive/hive/proteins/persistence/wallet.py
+++ b/core/src/aura_hive/hive/proteins/persistence/wallet.py
@@ -1,0 +1,44 @@
+"""WalletRepository — sanctified-wallet persistence, split out of PersistenceSkill.
+
+Tracks which wallets have been "sanctified" for a given asset domain. Methods
+are synchronous; callers wrap them in ``asyncio.to_thread`` exactly as the
+inline closures did before.
+"""
+
+from collections.abc import Callable
+
+from sqlalchemy.orm import Session
+
+from .engine import SanctifiedWallet
+
+
+class WalletRepository:
+    """Sanctified-wallet lookups over a session factory (`_get_session`)."""
+
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        self._session = session_factory
+
+    def sanctify(self, wallet_address: str, asset_domain: str) -> None:
+        with self._session() as session:
+            existing = (
+                session.query(SanctifiedWallet)
+                .filter_by(wallet_address=wallet_address)
+                .first()
+            )
+            if not existing:
+                session.add(
+                    SanctifiedWallet(
+                        wallet_address=wallet_address,
+                        asset_domain=asset_domain,
+                    )
+                )
+            session.commit()
+
+    def is_sanctified(self, wallet_address: str | None) -> bool:
+        with self._session() as session:
+            return (
+                session.query(SanctifiedWallet)
+                .filter_by(wallet_address=wallet_address)
+                .first()
+                is not None
+            )


### PR DESCRIPTION
## Summary

Fourth and final SQL slice of the `PersistenceSkill` god-protein decomposition (review follow-up #5):
- tissue enzymes (#235)
- `DealRepository` (#236)
- `ItemRepository` (#238)
- **`WalletRepository`** (this PR)

Sanctified-wallet lookups move into a `WalletRepository` bound to the session factory. The two wallet handlers (`_sanctify_wallet`, `_is_wallet_sanctified`) become thin `params -> repo -> Observation` delegators, removing the last inline session closures for wallet state.

After this, `PersistenceSkill` holds only cache/metabolic-cost logic and a capability→handler dispatch table — the entity SQL now lives in dedicated repositories.

## Notes

- `is_sanctified(wallet_address: str | None)` — the type is widened to `str | None` on purpose: the original handler did **not** validate `wallet_address`, so a missing address queries to no row and returns `False` (success) rather than an error. Behavior preserved.

## Verification
- `make lint` ✅
- `make test` ✅ (188 passed: core 114, api-gateway 1, telegram-bot 6, mcp-server 14, aura-worker 53)

🤖 Generated with [Claude Code](https://claude.com/claude-code)