### PR TITLE
refactor(transaction): extract C2C9 compliance guard from god-protein

### DIFF
--- a/core/src/aura_hive/hive/proteins/transaction/compliance.py
+++ b/core/src/aura_hive/hive/proteins/transaction/compliance.py
@@ -1,0 +1,49 @@
+"""C2C9 compliance guard: KYC/AML enforcement for RWA collateral release.
+
+Extracted from TransactionSkill so the transaction protein *delegates* the
+Membrane decision instead of embedding it. Pure logic over the HiveContext
+metadata; raises MetabolicSecurityError on a missing context or a compliance
+violation, exactly as the inline check did.
+"""
+
+from typing import Any
+
+import structlog
+
+from aura_hive.hive.metabolism import MetabolicSecurityError
+
+logger = structlog.get_logger(__name__)
+
+
+def enforce_rwa_compliance(context: Any, required_kyc: str, required_aml: str) -> None:
+    """C2C9 Membrane enforcement: raise unless KYC/AML clearance matches.
+
+    Args:
+        context: HiveContext carrying compliance metadata (google.protobuf.Struct).
+        required_kyc: KYC status required to release collateral.
+        required_aml: AML risk level required to release collateral.
+
+    Raises:
+        MetabolicSecurityError: if the context is missing or compliance fails.
+    """
+    if not context:
+        raise MetabolicSecurityError("Security context missing: HiveContext required")
+
+    # Extract metadata from Context (google.protobuf.Struct)
+    metadata = (
+        context.metadata.to_dict() if hasattr(context.metadata, "to_dict") else {}
+    )
+    kyc_status = metadata.get("kyc_status")
+    aml_risk = metadata.get("aml_risk")
+
+    if kyc_status != required_kyc or aml_risk != required_aml:
+        logger.error(
+            "c2c9_security_violation",
+            kyc_status=kyc_status,
+            aml_risk=aml_risk,
+            agent_did=metadata.get("agent_did", "unknown"),
+        )
+        raise MetabolicSecurityError(
+            f"C2C9 Membrane Violation: Compliance failure "
+            f"(KYC: {kyc_status}, AML: {aml_risk})"
+        )

--- a/core/src/aura_hive/hive/proteins/transaction/skill.py
+++ b/core/src/aura_hive/hive/proteins/transaction/skill.py
@@ -7,6 +7,7 @@ from aura_core_gen.aura.core.v1 import Observation
 from aura_hive.config.crypto import CryptoSettings
 from aura_hive.hive.metabolism import MetabolicSecurityError
 
+from .compliance import enforce_rwa_compliance
 from .engine import EVMProvider, PriceConverter, SecretEncryption
 from .schema import (
     PaymentProof,
@@ -224,38 +225,14 @@ class TransactionSkill(
         """
         C2C9 Membrane Enforcement: Release SPL Token transfer only if KYC/AML is cleared.
         """
-        # 1. Access context metadata for security enforcement
-        context = params.get("_context")
-        if not context:
-            raise MetabolicSecurityError(
-                "Security context missing: HiveContext required"
-            )
-
-        # Extract metadata from Context (google.protobuf.Struct)
-        metadata = (
-            context.metadata.to_dict() if hasattr(context.metadata, "to_dict") else {}
-        )
-        kyc_status = metadata.get("kyc_status")
-        aml_risk = metadata.get("aml_risk")
-
-        # 2. Strict C2C9 Enforcement logic
+        # 1. Membrane guard: enforce KYC/AML compliance before any motor action.
         required_kyc = (
             self.settings.required_kyc_status if self.settings else "APPROVED"
         )
         required_aml = self.settings.required_aml_risk if self.settings else "LOW"
+        enforce_rwa_compliance(params.get("_context"), required_kyc, required_aml)
 
-        if kyc_status != required_kyc or aml_risk != required_aml:
-            logger.error(
-                "c2c9_security_violation",
-                kyc_status=kyc_status,
-                aml_risk=aml_risk,
-                agent_did=metadata.get("agent_did", "unknown"),
-            )
-            raise MetabolicSecurityError(
-                f"C2C9 Membrane Violation: Compliance failure (KYC: {kyc_status}, AML: {aml_risk})"
-            )
-
-        # 3. Execution (Motor Neuron action)
+        # 2. Execution (Motor Neuron action)
         if not self.solana_provider:
             return Observation(success=False, error="solana_provider_not_initialized")
 


### PR DESCRIPTION
## Summary

Continues the god-protein decomposition (review follow-up #5) into `TransactionSkill`.

Unlike `PersistenceSkill`, `TransactionSkill`'s handlers already delegate to engines (`SolanaProvider`, `EVMProvider`, `SecretEncryption`, `PriceConverter`) — **except** `_execute_rwa_collateral`, which embedded the C2C9 Membrane KYC/AML compliance check inline. That is a **Membrane guard fused into a Connector handler** — the same drift the review flagged for `RuleBasedStrategy` inside the transformer.

This PR moves the enforcement into `compliance.enforce_rwa_compliance` — a pure guard that raises `MetabolicSecurityError` on a missing context or a compliance violation, with the **identical error message**. The handler now computes the required KYC/AML thresholds from settings and delegates the decision, then proceeds to the motor action.

## Scope note

This is the *only* substantive extraction target in `TransactionSkill` — the remaining 13 handlers are already thin delegators, so no repository-style split applies. This slice removes the last embedded business/security logic from the protein.

## Verification
- `make lint` ✅
- `make test` ✅ (188 passed: core 114, api-gateway 1, telegram-bot 6, mcp-server 14, aura-worker 53)

🤖 Generated with [Claude Code](https://claude.com/claude-code)