### PR TITLE
feat(ontology): measured fractal_completeness gate + ATCG-M patterns.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ lint: $(PROTO_SENTINEL)
 	MYPYPATH=$(DNA_PATH) uv run mypy packages/aura-core/src
 	# Security Audit (Bandit)
 	uv run bandit -r . -c pyproject.toml
+	# Fractal Completeness (ATCG-M baseline-lock gate)
+	uv run python tools/check_fractal_completeness.py
 	# Frontend Lint
 	# cd frontend && bun run lint
 

--- a/docs/ontology/patterns.yaml
+++ b/docs/ontology/patterns.yaml
@@ -1,0 +1,66 @@
+# Canonical ATCG-M fractal pattern + per-service completeness baseline.
+#
+# tools/check_fractal_completeness.py enforces this file as a CI gate (wired into
+# `make lint`, run by the `quality` job). Semantics are BASELINE-LOCK:
+#   - `present` is the locked floor. If a service loses a nucleotide it currently
+#     has, the checker FAILS (fractal regression).
+#   - The gap between `present` and the full five-nucleotide set is the documented
+#     drift from the 2026-07-24 ATCG-M review — informational, never blocking.
+#   - When a gap is closed (a missing nucleotide appears), the checker prints a
+#     nudge to tighten the baseline here. Drift may only improve.
+#
+# See docs/CLAUDE.md and docs/knowledge/hive_architecture_v2.json (distill self-model).
+
+version: 1
+
+# The five ATCG-M nucleotides every complete cell implements, sequenced by the
+# metabolism loop:  M(in) -> A -> T -> M(out) -> C -> G
+nucleotides:
+  A:
+    module: aggregator
+    role: "perceive — normalize the inbound signal"
+  T:
+    module: transformer
+    role: "think — reasoning / strategy"
+  C:
+    module: connector
+    role: "act — outbound side effects"
+  G:
+    module: generator
+    role: "pulse — emit observations / events"
+  M:
+    module: membrane
+    role: "guard — inbound/outbound boundary, Hidden-Knowledge enforcement"
+
+# metabolism is the orchestrating loop, not a nucleotide; a complete cell has it.
+orchestrator:
+  module: metabolism
+  role: "MetabolicLoop — sequences the nucleotides"
+
+# Per-service baseline. `present` is the locked floor; a full cell has all five
+# nucleotides A/T/C/G/M. `complete: false` services carry the documented review
+# drift — the checker records the gap but does not block on it.
+services:
+  core:
+    hive_root: core/src/aura_hive/hive
+    present: [A, T, C, G, M]
+    orchestrator: true
+    complete: true          # the one full cell
+
+  bee-keeper:
+    hive_root: agents/bee-keeper/src/aura_keeper/hive
+    present: [A, T, C, G]
+    orchestrator: false
+    complete: false         # gap: M (membrane)
+
+  bee-evolver:
+    hive_root: agents/bee-evolver/src/hive
+    present: [A, T, C, G]
+    orchestrator: false
+    complete: false         # gap: M (membrane)
+
+  frontend:
+    hive_root: frontend/src/hive
+    present: [A, T, C, M]
+    orchestrator: false
+    complete: false         # gap: G (generator)

--- a/tools/check_fractal_completeness.py
+++ b/tools/check_fractal_completeness.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Fractal-completeness gate: measure ATCG-M nucleotide coverage per service.
+
+Reads ``docs/ontology/patterns.yaml`` and enforces a BASELINE-LOCK on the
+``fractal_completeness`` invariant (self-model rule ``fractal_completeness``):
+a service must not lose a nucleotide it currently has. This is the repo-native,
+CI-runnable measurement of what CGIS ``cgis_drift`` reports interactively — no
+external MCP server required.
+
+Exit status:
+  0  every service still has its baseline nucleotides (drift flat or improved)
+  1  regression: a declared-present nucleotide is missing on disk
+  2  the patterns file is malformed or absent
+
+Wired into ``make lint`` so the ``quality`` CI job runs it on every PR.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+PATTERNS = Path("docs/ontology/patterns.yaml")
+
+
+def _module_exists(hive_root: Path, module: str) -> bool:
+    """A nucleotide is present as a package dir or a single-file module."""
+    base = hive_root / module
+    if base.is_dir():
+        return True
+    return any(
+        (hive_root / f"{module}{ext}").is_file()
+        for ext in (".py", ".ts", ".tsx", ".js")
+    )
+
+
+def main(root: Path) -> int:
+    patterns_path = root / PATTERNS
+    if not patterns_path.is_file():
+        print(f"FATAL: {PATTERNS} not found", file=sys.stderr)
+        return 2
+
+    try:
+        spec = yaml.safe_load(patterns_path.read_text())
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive
+        print(f"FATAL: cannot parse {PATTERNS}: {exc}", file=sys.stderr)
+        return 2
+
+    nucleotides = spec["nucleotides"]  # code -> {module, role}
+    orchestrator_module = spec["orchestrator"]["module"]
+    full_set = set(nucleotides)
+
+    regressions: list[str] = []
+    improvements: list[str] = []
+
+    print("ATCG-M fractal completeness (baseline-lock)\n")
+    for name, svc in spec["services"].items():
+        hive_root = root / svc["hive_root"]
+        present = set(svc["present"])
+
+        # Baseline-lock: every declared-present nucleotide must exist on disk.
+        missing = [
+            code
+            for code in present
+            if not _module_exists(hive_root, nucleotides[code]["module"])
+        ]
+        for code in missing:
+            regressions.append(
+                f"{name}: nucleotide {code} ({nucleotides[code]['module']}) "
+                f"is in the baseline but missing at {svc['hive_root']}"
+            )
+
+        # Drift-may-only-improve: a closed gap should tighten the baseline.
+        gap = sorted(full_set - present)
+        appeared = [
+            code
+            for code in gap
+            if _module_exists(hive_root, nucleotides[code]["module"])
+        ]
+        for code in appeared:
+            improvements.append(
+                f"{name}: nucleotide {code} ({nucleotides[code]['module']}) now "
+                f"exists — tighten `present` in {PATTERNS}"
+            )
+
+        if svc.get("orchestrator") and not (hive_root / orchestrator_module).is_dir():
+            regressions.append(
+                f"{name}: orchestrator ({orchestrator_module}) is in the baseline "
+                f"but missing at {svc['hive_root']}"
+            )
+
+        coverage = f"{len(present)}/{len(full_set)}"
+        status = "COMPLETE" if svc.get("complete") else f"gap: {','.join(gap) or '-'}"
+        mark = "FAIL" if missing else "ok"
+        print(f"  [{mark:>4}] {name:<12} {coverage}  {status}")
+
+    print()
+    for line in improvements:
+        print(f"  improved: {line}")
+    for line in regressions:
+        print(f"  REGRESSION: {line}", file=sys.stderr)
+
+    if regressions:
+        print(f"\nfractal_completeness FAILED: {len(regressions)} regression(s)")
+        return 1
+    print("\nfractal_completeness OK: no service dropped below its baseline")
+    return 0
+
+
+if __name__ == "__main__":
+    # Resolve repo root relative to this file (tools/ -> repo root).
+    sys.exit(main(Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
## Summary

Review follow-up **#4** — turn the `fractal_completeness` invariant from a comment into a **measured CI gate**.

- **`docs/ontology/patterns.yaml`** — canonical, machine-readable ATCG-M pattern: the five nucleotides (A=aggregator, T=transformer, C=connector, G=generator, M=membrane) + the metabolism orchestrator, plus a **per-service completeness baseline** captured from ground truth.
- **`tools/check_fractal_completeness.py`** — **baseline-lock** checker: a service must not lose a nucleotide it currently has (regression → exit 1). Documented gaps are informational; a closed gap prints a nudge to tighten the baseline. Drift may only improve.
- **`Makefile`** — wires the checker into `make lint`, so the always-on `quality` CI job measures it on every PR.

## Current baseline (from ground truth)

```
[  ok] core         5/5  COMPLETE
[  ok] bee-keeper   4/5  gap: M
[  ok] bee-evolver  4/5  gap: M
[  ok] frontend     4/5  gap: G
```

## Why not `cgis_drift` (as the review named)

CGIS is an **interactive MCP server** — no CLI, unavailable in headless CI. This checker is the repo-native equivalent for the fractal-completeness dimension: deterministic, dependency-free, and it runs in the existing `quality` job with no external service. Writing it also surfaced that the review's shorthand "partial cells all miss membrane" was imprecise — **`frontend` has membrane and misses `generator`** instead; the baseline records the real state.

## Verification
- `make lint` ✅ (gate runs, exit 0 — baseline holds)
- `make test` ✅ (188 passed)
- Negative test: forcing a baseline nucleotide to be absent → checker exits 1 with a `REGRESSION:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)