### PR TITLE
docs(synapse): name the synapse mini-metabolism explicitly (A→T→C·G)

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -95,8 +95,12 @@ The self-model (`distill`) declares **6 hard invariants**. Honor them:
 | **bee-keeper** | `aura_keeper` | Citizen agent — audits the Hive's architecture (partial cell). | `python -m aura_keeper.main` |
 | **aura-worker** | `aura_worker` | Citizen — remote Jupyter/Colab vision worker (Ollama + gradio); frpc tunnel. | (Colab / worker node) |
 
-Synapses use a **`receptor → translator → effector`** shape — this is a lightweight
-mini-metabolism (receptor≈A, translator≈T, effector≈C/G), just not named as ATCG-M.
+Synapses use a **`receptor → translator → effector`** shape — a lightweight
+mini-metabolism with the ATCG-M mapping **receptor = A, translator = T,
+effector = C·G**. This is now stated explicitly in each synapse module's
+docstring and in `docs/ontology/patterns.yaml` (`synapse_pattern`). Applies to
+the NATS/MCP synapses (`telegram-bot`, `mcp-server`); `api-gateway` is an HTTP
+edge with a different shape.
 
 ## Development Commands
 

--- a/docs/ontology/patterns.yaml
+++ b/docs/ontology/patterns.yaml
@@ -37,6 +37,29 @@ orchestrator:
   module: metabolism
   role: "MetabolicLoop — sequences the nucleotides"
 
+# Synapses (edge protocol adapters) run a lighter mini-metabolism, not a full
+# cell: receptor -> translator -> effector. Named biologically in code; this
+# section makes the ATCG-M correspondence explicit (review follow-up #3). The
+# module docstrings in each synapse carry the same mapping.
+synapse_pattern:
+  stages:
+    receptor:
+      maps_to: [A]
+      role: "perceive — inbound stimulus enters the synapse"
+    translator:
+      maps_to: [T]
+      role: "think/transform — external language <-> Hive Signals/Observations"
+    effector:
+      maps_to: [C, G]
+      role: "act + pulse — apply decisions and emit events outward"
+  # Synapses implementing the receptor/translator/effector trio. api-gateway is
+  # an HTTP edge with a different shape and is intentionally excluded.
+  synapses:
+    telegram-bot:
+      root: synapses/telegram-bot/src/telegram_bot
+    mcp-server:
+      root: synapses/mcp-server/src/aura_mcp
+
 # Per-service baseline. `present` is the locked floor; a full cell has all five
 # nucleotides A/T/C/G/M. `complete: false` services carry the documented review
 # drift — the checker records the gap but does not block on it.

--- a/synapses/mcp-server/src/aura_mcp/effector.py
+++ b/synapses/mcp-server/src/aura_mcp/effector.py
@@ -1,3 +1,11 @@
+"""MCP synapse — Effector (ATCG-M phase C·G: Connector · Generator).
+
+Acts on Hive decisions and pulses events back out to MCP clients (background
+event propagation / notifications) — the combined C (act) and G (pulse) phases
+of the synapse mini-metabolism  receptor -> translator -> effector = A -> T -> C·G
+(docs/ontology/patterns.yaml).
+"""
+
 from typing import Any
 
 import nats

--- a/synapses/mcp-server/src/aura_mcp/receptor.py
+++ b/synapses/mcp-server/src/aura_mcp/receptor.py
@@ -1,3 +1,11 @@
+"""MCP synapse — Receptor (ATCG-M phase A: Aggregator).
+
+Perceives inbound stimuli: MCP tool calls from clients (e.g. Claude) enter the
+synapse here and trigger Metabolic Loop executions. This is the A phase of the
+synapse mini-metabolism  receptor -> translator -> effector = A -> T -> C·G
+documented in docs/ontology/patterns.yaml.
+"""
+
 from typing import cast
 
 import structlog

--- a/synapses/mcp-server/src/aura_mcp/translator.py
+++ b/synapses/mcp-server/src/aura_mcp/translator.py
@@ -1,3 +1,10 @@
+"""MCP synapse — Translator (ATCG-M phase T: Transformer).
+
+Transforms between the synapse's external language (MCP tool calls) and the
+Hive's internal Signals/Observations. The T phase of the synapse mini-metabolism
+receptor -> translator -> effector = A -> T -> C·G  (docs/ontology/patterns.yaml).
+"""
+
 import uuid
 from datetime import UTC, datetime
 from typing import Any, cast

--- a/synapses/telegram-bot/src/telegram_bot/effector.py
+++ b/synapses/telegram-bot/src/telegram_bot/effector.py
@@ -1,3 +1,10 @@
+"""Telegram synapse — Effector (ATCG-M phase C·G: Connector · Generator).
+
+Acts on Hive decisions and pulses events back out to Telegram/NATS — the
+combined C (act) and G (pulse) phases of the synapse mini-metabolism
+receptor -> translator -> effector = A -> T -> C·G  (docs/ontology/patterns.yaml).
+"""
+
 from typing import Any
 
 import betterproto

--- a/synapses/telegram-bot/src/telegram_bot/receptor.py
+++ b/synapses/telegram-bot/src/telegram_bot/receptor.py
@@ -1,3 +1,11 @@
+"""Telegram synapse — Receptor (ATCG-M phase A: Aggregator).
+
+Perceives inbound stimuli: Telegram messages and callbacks enter the synapse
+here and are handed to the Translator. This is the A phase of the synapse
+mini-metabolism  receptor -> translator -> effector = A -> T -> C·G  documented
+in docs/ontology/patterns.yaml.
+"""
+
 from io import BytesIO
 
 import betterproto

--- a/synapses/telegram-bot/src/telegram_bot/translator.py
+++ b/synapses/telegram-bot/src/telegram_bot/translator.py
@@ -1,3 +1,10 @@
+"""Telegram synapse — Translator (ATCG-M phase T: Transformer).
+
+Transforms between the synapse's external language (Telegram updates) and the
+Hive's internal Signals/Observations. The T phase of the synapse mini-metabolism
+receptor -> translator -> effector = A -> T -> C·G  (docs/ontology/patterns.yaml).
+"""
+
 import json
 import uuid
 from datetime import UTC, datetime

--- a/tools/check_fractal_completeness.py
+++ b/tools/check_fractal_completeness.py
@@ -96,6 +96,24 @@ def main(root: Path) -> int:
         mark = "FAIL" if missing else "ok"
         print(f"  [{mark:>4}] {name:<12} {coverage}  {status}")
 
+    # Synapse mini-metabolism: receptor -> translator -> effector (A -> T -> C·G).
+    synapse_spec = spec.get("synapse_pattern")
+    if synapse_spec:
+        stages = list(synapse_spec["stages"])
+        print(
+            "\nSynapse mini-metabolism (receptor->translator->effector = A->T->C·G)\n"
+        )
+        for name, syn in synapse_spec.get("synapses", {}).items():
+            syn_root = root / syn["root"]
+            missing = [s for s in stages if not _module_exists(syn_root, s)]
+            for stage in missing:
+                regressions.append(
+                    f"synapse {name}: stage {stage} missing at {syn['root']}"
+                )
+            mark = "FAIL" if missing else "ok"
+            present_stages = ",".join(s for s in stages if s not in missing)
+            print(f"  [{mark:>4}] {name:<12} {present_stages}")
+
     print()
     for line in improvements:
         print(f"  improved: {line}")


### PR DESCRIPTION
## Summary

Review follow-up **#3** — the synapse edge adapters already ran the biological `receptor → translator → effector` shape, but the ATCG-M correspondence was never stated. This makes it **explicit**.

- **Synapse module docstrings** — each of receptor/translator/effector (× `telegram-bot`, `mcp-server`) now names its phase:
  - `receptor` = **A** (Aggregator — perceive inbound stimulus)
  - `translator` = **T** (Transformer — external language ⇄ Hive Signals/Observations)
  - `effector` = **C·G** (Connector · Generator — act + pulse outward)
  - (telegram-bot's modules previously had *no* module docstring.)
- **`docs/ontology/patterns.yaml`** — new `synapse_pattern` section maps the trio to ATCG-M and lists the synapses that implement it. `api-gateway` is an HTTP edge with a different shape, intentionally excluded.
- **`tools/check_fractal_completeness.py`** — now verifies each declared synapse still has its receptor/translator/effector trio, so the naming is a *measured baseline*, not just prose (extends the #4 gate).
- **`docs/CLAUDE.md`** — tightens the synapse note from "≈ / not named as ATCG-M" to the explicit mapping, pointing at patterns.yaml.

## Checker output

```
Synapse mini-metabolism (receptor->translator->effector = A->T->C·G)

  [  ok] telegram-bot receptor,translator,effector
  [  ok] mcp-server   receptor,translator,effector
```

## Verification
- `make lint` ✅ (gate runs, exit 0)
- `make test` ✅ (188 passed)

Docstrings + ontology only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)