### PR TITLE
ci(evolver): expose dry_run as a workflow_dispatch input

### DIFF
--- a/.github/workflows/bee-evolver.yaml
+++ b/.github/workflows/bee-evolver.yaml
@@ -11,6 +11,11 @@ on:
         required: false
         default: ''
         type: string
+      dry_run:
+        description: 'Run the full cycle but open no PR or Issues (for cost-baseline collection)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   evolve:
@@ -61,6 +66,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           AURA_METABOLISM_LOG: ".hive/metabolism.jsonl"
           GITHUB_SHA: ${{ github.sha }}
+          # Empty on scheduled runs, so the fallback keeps the default off.
+          EVOLVER_DRY_RUN: ${{ inputs.dry_run || false }}
         run: |
           uv run --directory agents/bee-evolver python main.py
 

--- a/agents/bee-evolver/tests/test_dry_run.py
+++ b/agents/bee-evolver/tests/test_dry_run.py
@@ -30,6 +30,20 @@ def _plan() -> EvolutionPlan:
     )
 
 
+def test_dry_run_parses_the_string_forms_a_workflow_passes(tmp_path):
+    """The workflow sets EVOLVER_DRY_RUN from a boolean input, which reaches the
+    process as the string "true"/"false". This is the seam between the YAML and
+    the code — the switch existed for a while with no wire running to it."""
+    for raw, expected in (("true", True), ("false", False), ("1", True), ("0", False)):
+        settings = EvolverSettings(
+            AURA_LLM__API_KEY="test-key",
+            GITHUB_REPOSITORY="zaebee/aura",
+            AURA_METABOLISM_LOG=str(tmp_path / "metabolism.jsonl"),
+            EVOLVER_DRY_RUN=raw,
+        )
+        assert settings.dry_run is expected, f"{raw!r} should parse to {expected}"
+
+
 async def test_dry_run_makes_no_http_calls(tmp_path, monkeypatch):
     calls: list[str] = []
 


### PR DESCRIPTION
`EVOLVER_DRY_RUN` shipped in #243 as a config field and a Connector short-circuit — but nothing ever set it. **The switch had no wire running to it**, so a forced run would still open a PR and Issues, which is exactly what dry-run exists to avoid.

This adds the `workflow_dispatch` input and passes it through. The `|| false` fallback keeps the default off on scheduled runs, where `inputs.dry_run` is empty.

## Why now

It blocks the cheapest next step of Gate 0. Collecting a cost baseline needs forced Evolver cycles; without dry-run, each one opens a PR and issues, and the Evolver's own PRs land in git history — which feeds its own Aggregator, so the baseline would drift as a consequence of measuring it.

## Test

Adds coverage for the YAML/code seam: the workflow passes a boolean input that reaches the process as the string `"true"`/`"false"`, and nothing covered that conversion. Same class of gap as the missing wire — the parts each worked, the join between them was untested.

`make lint` and `make test` green (19 evolver + 7 keeper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)