### PR TITLE
fix(ci): write the metabolic record to an absolute path

### DIFF
--- a/.github/workflows/bee-evolver.yaml
+++ b/.github/workflows/bee-evolver.yaml
@@ -64,7 +64,7 @@ jobs:
           AURA_BEE_EVOLVER__MAX_TOKENS: "2000"
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          AURA_METABOLISM_LOG: ".hive/metabolism.jsonl"
+          AURA_METABOLISM_LOG: "${{ github.workspace }}/.hive/metabolism.jsonl"
           GITHUB_SHA: ${{ github.sha }}
           # Empty on scheduled runs, so the fallback keeps the default off.
           EVOLVER_DRY_RUN: ${{ inputs.dry_run || false }}

--- a/agents/bee-evolver/tests/test_dry_run.py
+++ b/agents/bee-evolver/tests/test_dry_run.py
@@ -30,7 +30,7 @@ def _plan() -> EvolutionPlan:
     )
 
 
-def test_dry_run_parses_the_string_forms_a_workflow_passes(tmp_path):
+def test_dry_run_parses_workflow_string_inputs():
     """The workflow sets EVOLVER_DRY_RUN from a boolean input, which reaches the
     process as the string "true"/"false". This is the seam between the YAML and
     the code — the switch existed for a while with no wire running to it."""
@@ -38,7 +38,6 @@ def test_dry_run_parses_the_string_forms_a_workflow_passes(tmp_path):
         settings = EvolverSettings(
             AURA_LLM__API_KEY="test-key",
             GITHUB_REPOSITORY="zaebee/aura",
-            AURA_METABOLISM_LOG=str(tmp_path / "metabolism.jsonl"),
             EVOLVER_DRY_RUN=raw,
         )
         assert settings.dry_run is expected, f"{raw!r} should parse to {expected}"


### PR DESCRIPTION
The Evolver runs via `uv run --directory agents/bee-evolver`, which changes the working directory. The relative `AURA_METABOLISM_LOG` therefore resolved under `agents/bee-evolver/.hive/`, while the assert and upload steps looked at the repo root. The record was written correctly — and then not found.

Caught on the **first live run** ([30718271423](https://github.com/zaebee/aura/actions/runs/30718271423)), which is precisely what the assert step is for. The writer swallows its own errors by design so it can never crash the bee, which means nothing inside the agent could have reported this. The check outside it turned a silent misplacement into a red job on cycle one, instead of an empty dataset discovered weeks later.

## Separate finding from the same run — not fixed here

**bee.Evolver's LLM has been failing for at least seven weeks, and every run reported success.**

```
litellm.AuthenticationError: MistralException - {"detail":"Unauthorized"}
litellm.AuthenticationError: OpenAIException - Incorrect API key provided: 004h5xib********aiVi
```

Both the primary key and the fallback are invalid. The same errors appear in the scheduled run of 2026-07-27, and every scheduled run back to 2026-06-15 is green. Each one produced `improvements=0`, no PR, and a Telegram message announcing completion.

It exits 0 because `main.py` checks `if not observation.success and not observation.plan` — the plan object exists (carrying the narrative "The Evolver's brain is offline"), so the guard does not fire.

Two consequences worth separating:

- **Gate 0 is blocked on a credential, not on engineering.** No cost data can be collected until the keys are valid. The failed run cost nothing — auth fails before any tokens are spent.
- **Consider making a total brain failure exit non-zero.** That is why seven weeks passed unnoticed. Not changed here: it alters the bee's failure semantics and deserves its own decision.

With the record in place, `outcome=llm_error` would have surfaced this on the first cycle rather than the seventh week — an unplanned demonstration of what the instrumentation is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)