### PR TITLE
fix(evolver): log why a patch failed to apply

### DIFF
--- a/agents/bee-evolver/src/hive/generator/__init__.py
+++ b/agents/bee-evolver/src/hive/generator/__init__.py
@@ -106,7 +106,20 @@ class EvolverGenerator:
                         f"Patch for '{imp.title}' failed dry-run: "
                         f"{result.stderr.strip()[:200]}"
                     )
-                    logger.warning("patch_dry_run_failed", title=imp.title)
+                    # git's stderr says exactly WHY the patch will not apply. It
+                    # used to reach only the returned message, which the
+                    # Connector reports — and dry-run short-circuits the
+                    # Connector, so during baseline collection the reason was
+                    # unobservable. The diff header goes with it: a wrong target
+                    # path fails identically to a malformed hunk, and the two
+                    # need different fixes.
+                    logger.warning(
+                        "patch_dry_run_failed",
+                        title=imp.title,
+                        target_file=imp.target_file,
+                        error=result.stderr.strip()[:300],
+                        patch_header=" | ".join(imp.patch.splitlines()[:4]),
+                    )
                     return msg
 
                 subprocess.run(  # nosec

--- a/agents/bee-evolver/src/hive/generator/__init__.py
+++ b/agents/bee-evolver/src/hive/generator/__init__.py
@@ -118,7 +118,7 @@ class EvolverGenerator:
                         title=imp.title,
                         target_file=imp.target_file,
                         error=result.stderr.strip()[:300],
-                        patch_header=" | ".join(imp.patch.splitlines()[:4]),
+                        patch_header=" | ".join(imp.patch[:1000].splitlines()[:4]),
                     )
                     return msg
 


### PR DESCRIPTION
The first live Evolver cycle after the keys were fixed produced **3 proposals, 0 applied** — and no way to see why.

`git apply --check` writes the reason to stderr, but the warning carried only the improvement title:

```python
logger.warning("patch_dry_run_failed", title=imp.title)
```

The reason did reach the returned message, which the Connector reports. But dry-run short-circuits the Connector — so in exactly the mode used for baseline collection, the failure was unobservable.

Now logs `error` (git's stderr), `target_file`, and the first four lines of the diff. That last one matters because a patch aimed at a path that does not exist fails identically to one with a malformed hunk, and the two call for different fixes.

Diagnostic only — no behaviour change, `make lint` and 19 evolver tests green.

## Context

From the first successful metabolic record (run [30720058207](https://github.com/zaebee/aura/actions/runs/30720058207)):

```json
{"prompt_tokens": 1563, "completion_tokens": 1324, "usd": 0.0027675,
 "wall_clock_s": 21.024, "proposals": 3, "applied": 0,
 "outcome": "generator_error", "model": "mistral/mistral-large-latest"}
```

The instrumentation works end to end. A cycle costs about a third of a cent, which puts the whole 25-cycle §6 experiment at roughly 14 cents — the binding constraint was never money.

But `applied: 0` matters more than the cost: proposals that will not apply as diffs never reach a preflight, so any acceptance-rate guardrail defined over preflight has nothing to measure. Diagnosing that is the point of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)