### PR TITLE
Run bee.Keeper's audit in CI, and take the model out of its senses

### DIFF
--- a/.github/workflows/bee-keeper.yaml
+++ b/.github/workflows/bee-keeper.yaml
@@ -87,4 +87,6 @@ jobs:
           git config --global user.name "bee.Keeper"
           git config --global user.email "keeper@aura.hive"
 
-          # SKIP: PYTHONPATH=agents/bee-keeper/src uv run python -m aura_keeper.main
+          # One cycle, then exit. Without --once this is a NATS daemon that
+          # blocks until the job timeout.
+          PYTHONPATH=agents/bee-keeper/src uv run python -m aura_keeper.main --once

--- a/.github/workflows/bee-keeper.yaml
+++ b/.github/workflows/bee-keeper.yaml
@@ -87,6 +87,6 @@ jobs:
           git config --global user.name "bee.Keeper"
           git config --global user.email "keeper@aura.hive"
 
-          # One cycle, then exit. Without --once this is a NATS daemon that
-          # blocks until the job timeout.
-          PYTHONPATH=agents/bee-keeper/src uv run python -m aura_keeper.main --once
+          # PYTHONPATH lives in the Makefile: bee.Keeper needs aura_core and the
+          # generated protos as well as its own package.
+          make keeper-audit

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint mypy test test-cov test-verbose build generate push install-dev format test-health \
+.PHONY: lint mypy test test-cov test-verbose build generate push install-dev format test-health keeper-audit \
        run-core run-gateway run-frontend prepare-bun
 
 # Makefile for Aura Project
@@ -51,6 +51,10 @@ setup-hooks:
 	uv run pre-commit install
 
 # Run tests
+keeper-audit: $(PROTO_SENTINEL)
+	# One bee.Keeper cycle, then exit. Without --once main.py is a NATS daemon.
+	PYTHONPATH=$(KEEPER_PATH) uv run python -m aura_keeper.main --once
+
 test: $(PROTO_SENTINEL)
 	# Run core tests
 	PYTHONPATH=$(CORE_PATH) uv run pytest core/tests/ -v

--- a/agents/bee-keeper/src/aura_keeper/hive/aggregator/__init__.py
+++ b/agents/bee-keeper/src/aura_keeper/hive/aggregator/__init__.py
@@ -6,7 +6,6 @@ from typing import Any, cast
 
 import betterproto
 import httpx
-import litellm
 from datetime import UTC, datetime
 
 import structlog
@@ -39,10 +38,13 @@ class BeeAggregator(Aggregator[Any, Context]):
         self.prometheus_url = settings.prometheus_url
         self.repo_name = settings.github_repository
         self.event_path = settings.github_event_path
+        # Reported by the Transformer, which owns the model. The senses do not
+        # touch it: an Aggregator must be resultant, and a model call is not.
         self.brain_status: dict[str, bool] = {}
 
     async def perceive(self, signal: Any, **kwargs: Any) -> Context:
         event_name = kwargs.get("event_name", "manual")
+        self.brain_status = kwargs.get("brain_status", self.brain_status)
         logger.info("bee_aggregator_perceive_started", trigger_event=event_name)
 
         error_msg = ""
@@ -253,41 +255,3 @@ class BeeAggregator(Aggregator[Any, Context]):
             except Exception as e:
                 logger.warning("event_data_load_failed", error=str(e))
         return {}
-
-    async def test_brain_connectivity(self) -> bool:
-        """Pings the LLM endpoints to verify connectivity."""
-        logger.info("testing_brain_connectivity")
-        models = {
-            "primary": self.settings.llm__model,
-            "fallback": self.settings.llm__fallback_model,
-        }
-        # Reset status and ensure we have entries for both roles
-        self.brain_status = {role: False for role in models}
-
-        for role, model in models.items():
-            if not model:
-                continue
-            try:
-                logger.info("pinging_llm", role=role, model=model)
-
-                kwargs: dict[str, Any] = {
-                    "model": model,
-                    "messages": [{"role": "user", "content": "ping"}],
-                    "max_tokens": 5,
-                    "timeout": 10.0,
-                    "api_key": self.settings.llm__api_key,
-                }
-
-                if "ollama" in model:
-                    kwargs["api_base"] = self.settings.llm__ollama_base_url
-
-                # Simple completion to test connectivity via LiteLLM
-                await litellm.acompletion(**kwargs)
-
-                logger.info("llm_ping_success", role=role, model=model)
-                self.brain_status[role] = True
-            except Exception as e:
-                # Log as warning to ensure the Hive doesn't exit prematurely if at least one model is alive
-                logger.warning("llm_ping_failed", role=role, model=model, error=str(e))
-
-        return any(self.brain_status.values())

--- a/agents/bee-keeper/src/aura_keeper/hive/metabolism.py
+++ b/agents/bee-keeper/src/aura_keeper/hive/metabolism.py
@@ -41,7 +41,11 @@ class BeeMetabolism:
         try:
             # 1. Aggregator (A) - Senses the environment
             try:
-                context = await self.aggregator.perceive(None, event_name=event_name)
+                context = await self.aggregator.perceive(
+                    None,
+                    event_name=event_name,
+                    brain_status=self.transformer.brain_status,
+                )
             except Exception:
                 outcome = "aggregator_error"
                 raise

--- a/agents/bee-keeper/src/aura_keeper/hive/transformer/__init__.py
+++ b/agents/bee-keeper/src/aura_keeper/hive/transformer/__init__.py
@@ -56,6 +56,8 @@ class BeeTransformer(Transformer[Context, AuditObservation]):
         self.settings = settings
         self.model = settings.llm__model
         litellm.api_key = settings.llm__api_key
+        # The organ that owns the model also reports whether it answers.
+        self.brain_status: dict[str, bool] = {}
         # Metabolism instrumentation (Gate 0). bee.Keeper makes more than one
         # LLM call per cycle, so usage is accumulated rather than overwritten.
         self.usage_totals: dict[str, Any] = {}
@@ -125,6 +127,50 @@ class BeeTransformer(Transformer[Context, AuditObservation]):
                 self.manifest = yaml.safe_load(f)
         else:
             self.manifest = {}
+
+    async def test_brain_connectivity(self) -> bool:
+        """
+        Ping the configured models to verify connectivity.
+
+        Lives here rather than in the Aggregator: the Transformer is the only
+        organ permitted to call a model, and whether the brain answers is a
+        property of the brain, not of the senses.
+        """
+        logger.info("testing_brain_connectivity")
+        models = {
+            "primary": self.settings.llm__model,
+            "fallback": self.settings.llm__fallback_model,
+        }
+        # Reset status and ensure we have entries for both roles
+        self.brain_status = {role: False for role in models}
+
+        for role, model in models.items():
+            if not model:
+                continue
+            try:
+                logger.info("pinging_llm", role=role, model=model)
+
+                kwargs: dict[str, Any] = {
+                    "model": model,
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "max_tokens": 5,
+                    "timeout": 10.0,
+                    "api_key": self.settings.llm__api_key,
+                }
+
+                if "ollama" in model:
+                    kwargs["api_base"] = self.settings.llm__ollama_base_url
+
+                # Simple completion to test connectivity via LiteLLM
+                await litellm.acompletion(**kwargs)
+
+                logger.info("llm_ping_success", role=role, model=model)
+                self.brain_status[role] = True
+            except Exception as e:
+                # Log as warning to ensure the Hive doesn't exit prematurely if at least one model is alive
+                logger.warning("llm_ping_failed", role=role, model=model, error=str(e))
+
+        return any(self.brain_status.values())
 
     async def think(self, context: Context, **kwargs: Any) -> AuditObservation:
         """Main entry point for BeeKeeper reasoning."""

--- a/agents/bee-keeper/src/aura_keeper/hive/transformer/__init__.py
+++ b/agents/bee-keeper/src/aura_keeper/hive/transformer/__init__.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from typing import Any, cast
 
 import json
+import asyncio
+
 import litellm
 import structlog
 import yaml  # type: ignore
@@ -144,9 +146,7 @@ class BeeTransformer(Transformer[Context, AuditObservation]):
         # Reset status and ensure we have entries for both roles
         self.brain_status = {role: False for role in models}
 
-        for role, model in models.items():
-            if not model:
-                continue
+        async def ping(role: str, model: str) -> None:
             try:
                 logger.info("pinging_llm", role=role, model=model)
 
@@ -161,14 +161,16 @@ class BeeTransformer(Transformer[Context, AuditObservation]):
                 if "ollama" in model:
                     kwargs["api_base"] = self.settings.llm__ollama_base_url
 
-                # Simple completion to test connectivity via LiteLLM
                 await litellm.acompletion(**kwargs)
 
                 logger.info("llm_ping_success", role=role, model=model)
                 self.brain_status[role] = True
             except Exception as e:
-                # Log as warning to ensure the Hive doesn't exit prematurely if at least one model is alive
+                # A warning, not an error: one live model is enough to proceed.
                 logger.warning("llm_ping_failed", role=role, model=model, error=str(e))
+
+        # Concurrently: sequentially, two hanging endpoints cost two timeouts.
+        await asyncio.gather(*(ping(r, m) for r, m in models.items() if m))
 
         return any(self.brain_status.values())
 

--- a/agents/bee-keeper/src/aura_keeper/main.py
+++ b/agents/bee-keeper/src/aura_keeper/main.py
@@ -19,6 +19,35 @@ structlog.configure(
 logger = structlog.get_logger(__name__)
 
 
+async def audit_once() -> None:
+    """
+    Run a single metabolic cycle and exit.
+
+    CI needs an audit, not a daemon: `main()` below subscribes to NATS and
+    blocks in `async for msg in sub.messages` forever, so a workflow calling it
+    would hang until the job timeout. One cycle is A -> T -> C -> G and touches
+    no message bus.
+
+    The event name comes from settings rather than the environment directly —
+    bee.Keeper flags raw environment reads as a Pattern Heresy, and it should
+    not break its own rule. `execute()` skips the LLM audit for `schedule`,
+    which keeps heartbeat runs from spending honey.
+    """
+    settings = KeeperSettings()
+    event_name = settings.github_event_name or "manual"
+    logger.info("bee_keeper_audit_once", event=event_name)
+
+    metabolism = BeeMetabolism(settings)
+    try:
+        await metabolism.execute(event_name=event_name)
+    except Exception as e:
+        logger.error("bee_keeper_audit_failed", error=str(e), exc_info=True)
+        sys.exit(1)
+    finally:
+        if metabolism.connector:
+            await metabolism.connector.close()
+
+
 async def main() -> None:
     logger.info("bee_keeper_agent_starting")
 
@@ -33,7 +62,7 @@ async def main() -> None:
         metabolism = BeeMetabolism(settings)
 
         # 1.5 Sanity Check: Test Brain Connectivity
-        if not await metabolism.aggregator.test_brain_connectivity():
+        if not await metabolism.transformer.test_brain_connectivity():
             logger.error("Brain connectivity test failed. Check AURA_LLM__API_KEY.")
             # We don't exit here to allow for intermittent connectivity
             # sys.exit(1)
@@ -78,4 +107,7 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    if "--once" in sys.argv:
+        asyncio.run(audit_once())
+    else:
+        asyncio.run(main())

--- a/agents/bee-keeper/src/aura_keeper/main.py
+++ b/agents/bee-keeper/src/aura_keeper/main.py
@@ -37,14 +37,18 @@ async def audit_once() -> None:
     event_name = settings.github_event_name or "manual"
     logger.info("bee_keeper_audit_once", trigger_event=event_name)
 
-    metabolism = BeeMetabolism(settings)
+    metabolism = None
     try:
+        # Construction inside the try: a failure here — bad settings, a broken
+        # sub-component — would otherwise skip the structured log and surface as
+        # a bare traceback. main() below already does it this way.
+        metabolism = BeeMetabolism(settings)
         await metabolism.execute(event_name=event_name)
     except Exception as e:
         logger.error("bee_keeper_audit_failed", error=str(e), exc_info=True)
         sys.exit(1)
     finally:
-        if metabolism.connector:
+        if metabolism and metabolism.connector:
             await metabolism.connector.close()
 
 

--- a/agents/bee-keeper/src/aura_keeper/main.py
+++ b/agents/bee-keeper/src/aura_keeper/main.py
@@ -35,7 +35,7 @@ async def audit_once() -> None:
     """
     settings = KeeperSettings()
     event_name = settings.github_event_name or "manual"
-    logger.info("bee_keeper_audit_once", event=event_name)
+    logger.info("bee_keeper_audit_once", trigger_event=event_name)
 
     metabolism = BeeMetabolism(settings)
     try:


### PR DESCRIPTION
Two things the previous PR flagged and left open.

## The audit has never actually run

`bee-keeper.yaml` has its invocation commented out:

```
# SKIP: PYTHONPATH=agents/bee-keeper/src uv run python -m aura_keeper.main
```

Hive Audit has therefore been a green check over an empty job — 26 seconds of checkout, buf setup and kubectl tunnels, then exit.

**Uncommenting it as-is would have been worse than leaving it.** `aura_keeper.main` connects to NATS, subscribes to `aura.hive.events.error` and blocks in `async for msg in sub.messages` forever. In CI that hangs until the six-hour job timeout, on a self-hosted runner. That is almost certainly why it was disabled.

Added `audit_once()` and a `--once` flag: one metabolic cycle, A → T → C → G, no message bus, then exit. `execute()` was already a clean one-shot and needs no NATS. The event name comes from settings, so the existing `schedule` branch still skips the LLM audit and heartbeat runs stay cheap.

## The auditor was breaking the law it enforces

`BeeAggregator.test_brain_connectivity` called `litellm.acompletion` to ping the configured models. A model call in an organ that must be resultant — precisely what the determinism rule added in #250 exists to catch.

Moved to `BeeTransformer`, which already owns the model and sets its api key. Whether the brain answers is a property of the brain, not of the senses. `brain_status` is wired T → A through the metabolism, so the Generator's health reporting is unchanged.

`audit_once` reads the event name through `KeeperSettings` rather than the environment directly, since bee.Keeper flags raw environment reads as a Pattern Heresy.

## Still open, deliberately

The Generator imports litellm and it is **not** dead code — I removed it, mypy caught it, and I put it back. It calls `acompletion` to regenerate `llms.txt` from the proto definitions. Composing prose is reasoning and belongs in the Transformer, but moving it is a real refactor rather than an import removal. It stays, and the determinism rule still reports it.

## Cost note

With the invocation live, bee.Keeper now makes real LLM calls on every push and pull request. Scheduled runs are unaffected — `execute()` skips the audit for `schedule`. If the spend is unwelcome, the narrow fix is to widen that branch rather than to comment the invocation out again.

211 core tests pass; ruff, mypy and bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)