### PR TITLE
Make the Membrane intervention rate measurable: count it, and give the free phase memory

### DIFF
--- a/core/src/aura_hive/hive/connector/main.py
+++ b/core/src/aura_hive/hive/connector/main.py
@@ -144,20 +144,24 @@ class HiveConnector(BaseConnector):
         model wanted would teach it nothing about what the guard allowed, and
         the override rate is precisely what we want to be able to read later.
         """
-        hive = _get_hive(context)
-        if not hive or not hive.offer:
-            return
-        agent_did = getattr(hive.offer, "agent_did", "")
-        item_id = hive.item_identifier or ""
-        if not agent_did or not item_id:
+        try:
+            hive = _get_hive(context)
+            offer = getattr(hive, "offer", None) if hive else None
+            agent_did = getattr(offer, "agent_did", "") if offer else ""
+            item_id = getattr(hive, "item_identifier", "") if hive else ""
+            if not agent_did or not item_id:
+                return
+        except Exception:
             return
 
         reasoning = action.reasoning or ""
         turn = {
             "action": event_type,
-            "bid": float(getattr(hive.offer, "bid_amount", 0.0)),
-            "price": float(neg_intent.price) if neg_intent else 0.0,
-            "message": (neg_intent.message if neg_intent else "")[:280],
+            "bid": float(getattr(offer, "bid_amount", 0.0) or 0.0),
+            "price": float(getattr(neg_intent, "price", 0.0) or 0.0)
+            if neg_intent
+            else 0.0,
+            "message": str(getattr(neg_intent, "message", "") or "")[:280],
             # The guard leaves this marker when it replaces a decision. Carrying
             # it forward is what makes the override rate measurable per round.
             "membrane_override": "Membrane Override" in reasoning,
@@ -166,11 +170,15 @@ class HiveConnector(BaseConnector):
         }
 
         try:
-            await self.registry.execute(
+            obs = await self.registry.execute(
                 "persistence",
                 "append_negotiation_turn",
                 {"agent_did": agent_did, "item_id": item_id, "turn": turn},
             )
+            # The registry reports a skill failure by returning success=False,
+            # not by raising, so an except block alone would swallow it.
+            if not obs.success:
+                logger.warning("negotiation_turn_not_recorded", error=obs.error)
         except Exception as e:
             # A negotiation must not fail because its transcript could not be
             # written. Losing a turn degrades the next prompt; raising loses the deal.

--- a/core/src/aura_hive/hive/connector/main.py
+++ b/core/src/aura_hive/hive/connector/main.py
@@ -108,6 +108,8 @@ class HiveConnector(BaseConnector):
             logger.error("unknown_action_type", action=action_type)
             neg_obs.rejected = OfferRejected(reason_code="INTERNAL_ERROR")
 
+        await self._record_turn(action, context, neg_intent, event_type)
+
         obs_meta = _get_metadata_dict(context)
         obs_meta.update(
             {
@@ -126,6 +128,53 @@ class HiveConnector(BaseConnector):
             trace=context.trace,
             metadata=make_struct(obs_meta),
         )
+
+    async def _record_turn(
+        self,
+        action: Intent,
+        context: Context,
+        neg_intent: Any,
+        event_type: str,
+    ) -> None:
+        """
+        Append this round to the conversation, so the next one can see it.
+
+        Recorded here rather than in the Transformer because this is the
+        decision that actually went out — post-Membrane. A history of what the
+        model wanted would teach it nothing about what the guard allowed, and
+        the override rate is precisely what we want to be able to read later.
+        """
+        hive = _get_hive(context)
+        if not hive or not hive.offer:
+            return
+        agent_did = getattr(hive.offer, "agent_did", "")
+        item_id = hive.item_identifier or ""
+        if not agent_did or not item_id:
+            return
+
+        reasoning = action.reasoning or ""
+        turn = {
+            "action": event_type,
+            "bid": float(getattr(hive.offer, "bid_amount", 0.0)),
+            "price": float(neg_intent.price) if neg_intent else 0.0,
+            "message": (neg_intent.message if neg_intent else "")[:280],
+            # The guard leaves this marker when it replaces a decision. Carrying
+            # it forward is what makes the override rate measurable per round.
+            "membrane_override": "Membrane Override" in reasoning,
+            "agent_did": agent_did,
+            "item_id": item_id,
+        }
+
+        try:
+            await self.registry.execute(
+                "persistence",
+                "append_negotiation_turn",
+                {"agent_did": agent_did, "item_id": item_id, "turn": turn},
+            )
+        except Exception as e:
+            # A negotiation must not fail because its transcript could not be
+            # written. Losing a turn degrades the next prompt; raising loses the deal.
+            logger.warning("negotiation_turn_not_recorded", error=str(e))
 
     async def _handle_crypto_lock(
         self,

--- a/core/src/aura_hive/hive/membrane/main.py
+++ b/core/src/aura_hive/hive/membrane/main.py
@@ -57,6 +57,12 @@ def _record_intervention(direction: str, reason: str, **fields: Any) -> None:
     """Count it and say so. An intervention that leaves no trace cannot be measured."""
     try:
         membrane_interventions_total.labels(direction=direction, reason=reason).inc()
+        # Inside the try as well: **fields is caller-supplied and could fail to
+        # serialise, and a crash while reporting an intervention is the same
+        # failure as a crash while counting one.
+        logger.warning(
+            "membrane_intervention", direction=direction, reason=reason, **fields
+        )
     except Exception as e:
         # Accounting must never take the guarantee down with it. The decision
         # this call accompanies has already been made and still stands; losing a
@@ -64,9 +70,6 @@ def _record_intervention(direction: str, reason: str, **fields: Any) -> None:
         logger.error(
             "membrane_metric_failed", direction=direction, reason=reason, error=str(e)
         )
-    logger.warning(
-        "membrane_intervention", direction=direction, reason=reason, **fields
-    )
 
 
 def _action_label(action: Any) -> str:

--- a/core/src/aura_hive/hive/membrane/main.py
+++ b/core/src/aura_hive/hive/membrane/main.py
@@ -11,10 +11,44 @@ from aura_core_gen.aura.core.v1 import (
     RWAVaultIntent,
     TradeIntent,
 )
+from prometheus_client import REGISTRY, Counter
 
 from aura_hive.config import get_settings
 
 logger = structlog.get_logger(__name__)
+
+
+def _get_counter(name: str, documentation: str, labelnames: list[str]) -> Counter:
+    """
+    Idempotent registration: the default REGISTRY raises on a duplicate name,
+    and tests import this module more than once.
+
+    Defined here rather than imported from the telemetry protein: the Membrane
+    is a nucleus organ and proteins sit a level below it. Four lines of
+    duplication beat an upward dependency.
+    """
+    if name in REGISTRY._names_to_collectors:
+        return cast(Counter, REGISTRY._names_to_collectors[name])
+    return Counter(name, documentation, labelnames)
+
+
+# Every time the guard changed or refused what the Transformer produced. This is
+# the rate to watch: it measures how often free reasoning lands somewhere the
+# guarantee has to catch, which is the only number that says whether the
+# membrane is earning its place.
+membrane_interventions_total = _get_counter(
+    "membrane_interventions_total",
+    "Decisions the Membrane altered, sanitised or rejected",
+    ["direction", "reason"],
+)
+
+
+def _record_intervention(direction: str, reason: str, **fields: Any) -> None:
+    """Count it and say so. An intervention that leaves no trace cannot be measured."""
+    membrane_interventions_total.labels(direction=direction, reason=reason).inc()
+    logger.warning(
+        "membrane_intervention", direction=direction, reason=reason, **fields
+    )
 
 
 def _action_label(action: Any) -> str:
@@ -46,7 +80,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
             bid_amount = getattr(signal, "bid_amount", 0.0)
 
         if bid_amount < 0:
-            logger.warning("membrane_inbound_invalid_bid", bid_amount=bid_amount)
+            _record_intervention("inbound", "INVALID_BID", bid_amount=bid_amount)
             raise ValueError("Bid amount must be positive")
 
         injection_patterns = [
@@ -83,8 +117,9 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                 lowered_val = value.lower()
                 for pattern in injection_patterns:
                     if pattern in lowered_val:
-                        logger.warning(
-                            "membrane_inbound_injection_detected",
+                        _record_intervention(
+                            "inbound",
+                            "PROMPT_INJECTION",
                             field=field_name,
                             pattern=pattern,
                         )
@@ -130,8 +165,9 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
         if params_name == "rwa_vault" and params_value is not None:
             rwa_intent = cast(RWAVaultIntent, params_value)
             if not rwa_intent.compliance.kyc_passed:
-                logger.warning(
-                    "membrane_blocked_kyc_failure",
+                _record_intervention(
+                    "outbound",
+                    "KYC_FAILURE",
                     violation_code=rwa_intent.compliance.violation_code,
                     wallet_address=rwa_intent.wallet_address,
                 )
@@ -149,8 +185,9 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
             risk_score = trade_intent.validation_score.risk_score
             risk_threshold = getattr(self.settings.safety, "trade_risk_threshold", 0.10)
             if risk_score > risk_threshold:
-                logger.warning(
-                    "membrane_blocked_high_risk_trade",
+                _record_intervention(
+                    "outbound",
+                    "HIGH_RISK_TRADE",
                     risk_score=risk_score,
                     risk_category=trade_intent.validation_score.risk_category,
                 )
@@ -191,6 +228,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
             if neg_intent:
                 neg_intent.message = "I cannot disclose internal pricing details."
             decision.reasoning += " [MEMBRANE: DLP block]"
+            _record_intervention("outbound", "DLP_BLOCK")
 
         if decision.action not in [
             ActionType.ACTION_TYPE_ACCEPT,
@@ -237,6 +275,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
     def _override_with_safe_offer(
         self, original: Intent, safe_price: float, reason: str
     ) -> Intent:
+        _record_intervention("outbound", reason, safe_price=round(safe_price, 2))
         rounded_price = round(safe_price, 2)
         params_name, params_value = betterproto.which_one_of(original, "params")
         neg_intent = params_value if params_name == "negotiation" else None

--- a/core/src/aura_hive/hive/membrane/main.py
+++ b/core/src/aura_hive/hive/membrane/main.py
@@ -27,8 +27,18 @@ def _get_counter(name: str, documentation: str, labelnames: list[str]) -> Counte
     is a nucleus organ and proteins sit a level below it. Four lines of
     duplication beat an upward dependency.
     """
-    if name in REGISTRY._names_to_collectors:
-        return cast(Counter, REGISTRY._names_to_collectors[name])
+    existing = REGISTRY._names_to_collectors.get(name)
+    if existing is not None:
+        # Same name, different labels is a mistake that would otherwise surface
+        # far from its cause — as a ValueError inside .labels() at the first
+        # intervention. Raise where the mismatch was introduced.
+        registered = getattr(existing, "_labelnames", None)
+        if registered is not None and tuple(registered) != tuple(labelnames):
+            raise ValueError(
+                f"collector {name!r} is already registered with labels "
+                f"{tuple(registered)!r}, not {tuple(labelnames)!r}"
+            )
+        return cast(Counter, existing)
     return Counter(name, documentation, labelnames)
 
 
@@ -45,7 +55,15 @@ membrane_interventions_total = _get_counter(
 
 def _record_intervention(direction: str, reason: str, **fields: Any) -> None:
     """Count it and say so. An intervention that leaves no trace cannot be measured."""
-    membrane_interventions_total.labels(direction=direction, reason=reason).inc()
+    try:
+        membrane_interventions_total.labels(direction=direction, reason=reason).inc()
+    except Exception as e:
+        # Accounting must never take the guarantee down with it. The decision
+        # this call accompanies has already been made and still stands; losing a
+        # count degrades observability, raising here would lose the negotiation.
+        logger.error(
+            "membrane_metric_failed", direction=direction, reason=reason, error=str(e)
+        )
     logger.warning(
         "membrane_intervention", direction=direction, reason=reason, **fields
     )

--- a/core/src/aura_hive/hive/proteins/persistence/engine.py
+++ b/core/src/aura_hive/hive/proteins/persistence/engine.py
@@ -1,10 +1,12 @@
 import enum
+import hashlib
 import json
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
 import redis.asyncio as redis
+import structlog
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
     Boolean,
@@ -114,6 +116,22 @@ class MetabolicCost(Base):
     )
 
 
+logger = structlog.get_logger(__name__)
+
+
+def negotiation_history_key(agent_did: str, item_id: str) -> str:
+    """
+    Stable key for one (agent, item) conversation.
+
+    Hashed rather than interpolated: a DID or item id may contain the delimiter,
+    so `a:b` + `c` and `a` + `b:c` would otherwise collide, and either can be
+    long enough to make an awkward key. The plain values are stored inside each
+    turn, so a key can still be traced back.
+    """
+    digest = hashlib.sha256(f"{agent_did}\x00{item_id}".encode()).hexdigest()
+    return f"negotiation:history:{digest[:32]}"
+
+
 class RedisCache:
     """Redis-based caching and excited state storage."""
 
@@ -147,6 +165,55 @@ class RedisCache:
         if data:
             return cast(dict[str, Any], json.loads(data))
         return None
+
+    # ------------------------------------------------------------------
+    # Negotiation history
+    #
+    # Turns are grouped by (agent_did, item_id) because the wire protocol
+    # carries no conversation identifier: NegotiateRequest has request_id,
+    # item_id, bid_amount, currency_code and agent, and session_token is
+    # derived per request. Two independent negotiations by the same agent over
+    # the same item therefore merge into one history; the TTL bounds how long.
+    # Fixing that properly means adding a conversation_id to the proto.
+    # ------------------------------------------------------------------
+
+    async def append_negotiation_turn(
+        self,
+        agent_did: str,
+        item_id: str,
+        turn: dict[str, Any],
+        ttl: int = 3600,
+        cap: int = 20,
+    ) -> None:
+        """
+        Append one turn, keeping the most recent `cap`.
+
+        A Redis list rather than a JSON blob: RPUSH is atomic, so concurrent
+        turns cannot lose each other the way read-modify-write would, and LTRIM
+        bounds the prompt this history will end up in.
+        """
+        key = negotiation_history_key(agent_did, item_id)
+        pipe = self.redis.pipeline()
+        pipe.rpush(key, json.dumps(turn))
+        pipe.ltrim(key, -cap, -1)
+        pipe.expire(key, ttl)
+        await pipe.execute()
+
+    async def get_negotiation_history(
+        self, agent_did: str, item_id: str
+    ) -> list[dict[str, Any]]:
+        """Turns oldest first. A malformed entry is skipped, never fatal."""
+        key = negotiation_history_key(agent_did, item_id)
+        # redis-py types lrange as sync-or-async; the asyncio client always
+        # returns an awaitable.
+        raw = cast(list[Any], await self.redis.lrange(key, 0, -1))  # type: ignore[misc]
+        history: list[dict[str, Any]] = []
+        for entry in raw:
+            try:
+                history.append(json.loads(entry))
+            except (TypeError, ValueError):
+                logger.warning("negotiation_history_entry_unreadable", key=key)
+        return history
 
     async def delete_excited_state(self, deal_id: str) -> None:
         """Remove deal from 'Excited' state."""

--- a/core/src/aura_hive/hive/proteins/persistence/skill.py
+++ b/core/src/aura_hive/hive/proteins/persistence/skill.py
@@ -49,6 +49,8 @@ class PersistenceSkill(
             "read_item": self._read_item_handler,
             "create_deal": self._create_deal,
             "set_excited_state": self._set_excited_state,
+            "append_negotiation_turn": self._append_negotiation_turn,
+            "get_negotiation_history": self._get_negotiation_history,
             "confirm_ground_state": self._confirm_ground_state,
             "get_deal_by_memo": self._get_deal_by_memo_handler,
             "get_deal_by_id": self._get_deal_by_id_handler,
@@ -176,6 +178,39 @@ class PersistenceSkill(
                 str(deal_id), params, ttl=params.get("ttl", 3600)
             )
             return Observation(success=True)
+        except Exception as e:
+            return Observation(success=False, error=str(e))
+
+    async def _append_negotiation_turn(self, params: dict[str, Any]) -> Observation:
+        if not self.cache:
+            return Observation(success=False, error="cache_not_initialized")
+        agent_did = str(params.get("agent_did", ""))
+        item_id = str(params.get("item_id", ""))
+        turn = params.get("turn")
+        if not agent_did or not item_id or not isinstance(turn, dict):
+            return Observation(
+                success=False, error="agent_did, item_id and turn are required"
+            )
+        try:
+            await self.cache.append_negotiation_turn(
+                agent_did, item_id, turn, ttl=int(params.get("ttl", 3600))
+            )
+            return Observation(success=True)
+        except Exception as e:
+            return Observation(success=False, error=str(e))
+
+    async def _get_negotiation_history(self, params: dict[str, Any]) -> Observation:
+        if not self.cache:
+            return Observation(success=False, error="cache_not_initialized")
+        agent_did = str(params.get("agent_did", ""))
+        item_id = str(params.get("item_id", ""))
+        if not agent_did or not item_id:
+            return Observation(
+                success=False, error="agent_did and item_id are required"
+            )
+        try:
+            history = await self.cache.get_negotiation_history(agent_did, item_id)
+            return Observation(success=True, metadata=make_struct({"history": history}))
         except Exception as e:
             return Observation(success=False, error=str(e))
 

--- a/core/src/aura_hive/hive/transformer/main.py
+++ b/core/src/aura_hive/hive/transformer/main.py
@@ -420,7 +420,11 @@ class AuraTransformer(Transformer[Context, Intent]):
             )
             if not obs.success:
                 return []
-            history = _as_dict(obs.metadata).get("history", [])
+            # `.to_dict()`, not `_as_dict`: a betterproto Struct is not a dict,
+            # so the isinstance check there returns {} and the history silently
+            # stays empty. Same call the RWA and trade paths already use.
+            meta: dict[str, Any] = obs.metadata.to_dict() if obs.metadata else {}
+            history: Any = meta.get("history", [])
             return (
                 cast(list[dict[str, Any]], history) if isinstance(history, list) else []
             )

--- a/core/src/aura_hive/hive/transformer/main.py
+++ b/core/src/aura_hive/hive/transformer/main.py
@@ -394,6 +394,40 @@ class AuraTransformer(Transformer[Context, Intent]):
             trade=trade_intent,
         )
 
+    async def _load_history(self, context: Context) -> list[dict[str, Any]]:
+        """
+        Prior turns of this conversation, oldest first.
+
+        Empty is a valid answer and must never be fatal: a cold cache, an
+        unreachable Redis or a first contact all mean the same thing to the
+        model — no history — and none of them should fail a negotiation.
+        """
+        try:
+            # Inside the try: a context shaped differently than expected must
+            # degrade to no history, not fail the negotiation.
+            hive = _get_hive(context)
+            if not hive:
+                return []
+            item_id = getattr(hive, "item_identifier", "")
+            offer = getattr(hive, "offer", None)
+            agent_did = getattr(offer, "agent_did", "") if offer else ""
+            if not item_id or not agent_did:
+                return []
+            obs = await self.registry.execute(
+                "persistence",
+                "get_negotiation_history",
+                {"agent_did": agent_did, "item_id": item_id},
+            )
+            if not obs.success:
+                return []
+            history = _as_dict(obs.metadata).get("history", [])
+            return (
+                cast(list[dict[str, Any]], history) if isinstance(history, list) else []
+            )
+        except Exception as e:
+            logger.warning("negotiation_history_unavailable", error=str(e))
+            return []
+
     async def think(self, context: Context, **kwargs: Any) -> Intent:
         """Reason about the negotiation by calling the Reasoning Protein."""
 
@@ -432,7 +466,7 @@ class AuraTransformer(Transformer[Context, Intent]):
                 {
                     "bid": bid,
                     "context": self._build_economic_context(context),
-                    "history": [],
+                    "history": await self._load_history(context),
                 },
             )
 

--- a/core/tests/test_membrane_metrics.py
+++ b/core/tests/test_membrane_metrics.py
@@ -9,6 +9,7 @@ broken, and without a counter you cannot tell which.
 """
 
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from aura_core import SkillRegistry
@@ -133,6 +134,28 @@ class TestOutbound:
         assert count("outbound", "DLP_BLOCK") == before + 1
 
 
+class TestFailSafe:
+    @pytest.mark.asyncio
+    async def test_a_broken_metric_does_not_take_the_guard_down(self) -> None:
+        """
+        Accounting must never cost a guarantee.
+
+        The decision this call accompanies has already been made. Losing a count
+        degrades observability; raising here would lose the negotiation, which is
+        strictly worse and buys no safety.
+        """
+        membrane = guarded_membrane()
+
+        with patch("aura_hive.hive.membrane.main.membrane_interventions_total") as m:
+            m.labels.side_effect = RuntimeError("registry corrupted")
+            decision = await membrane.inspect_outbound(
+                counter_intent(price=500.0), negotiation_context(floor_price=1000.0)
+            )
+
+        assert "Membrane Override" in decision.reasoning
+        assert decision.negotiation.price == 1050.0
+
+
 class TestSeriesShape:
     def test_direction_and_reason_are_separate_labels(self) -> None:
         """Aggregating by reason alone would merge an inbound and outbound rate."""
@@ -140,8 +163,17 @@ class TestSeriesShape:
         assert set(sample.labels) == {"direction", "reason"}
 
     def test_registering_twice_reuses_the_same_collector(self) -> None:
-        """Tests import this module repeatedly; a duplicate name raises."""
+        """Tests import this module repeatedly; a duplicate name would raise."""
         from aura_hive.hive.membrane.main import _get_counter
 
-        again = _get_counter("membrane_interventions_total", "ignored", ["x"])
+        again = _get_counter(
+            "membrane_interventions_total", "ignored", ["direction", "reason"]
+        )
         assert again is membrane_interventions_total
+
+    def test_the_same_name_with_different_labels_raises(self) -> None:
+        """Otherwise the mismatch surfaces inside .labels(), far from its cause."""
+        from aura_hive.hive.membrane.main import _get_counter
+
+        with pytest.raises(ValueError, match="already registered with labels"):
+            _get_counter("membrane_interventions_total", "ignored", ["something_else"])

--- a/core/tests/test_membrane_metrics.py
+++ b/core/tests/test_membrane_metrics.py
@@ -1,0 +1,147 @@
+"""
+The Membrane counts its own interventions.
+
+Until this existed there was no way to ask how often free reasoning landed
+somewhere the guarantee had to catch — the override rewrote the Intent and left
+nothing behind but a string in a reasoning field. That rate is the number worth
+watching: a membrane that never fires is either perfectly redundant or silently
+broken, and without a counter you cannot tell which.
+"""
+
+from typing import Any
+
+import pytest
+from aura_core import SkillRegistry
+from aura_core.struct_utils import make_struct
+from aura_core_gen.aura.core.v1 import ActionType, Context, Intent, NegotiationIntent
+from aura_hive.hive.membrane.main import (
+    HiveMembrane,
+    membrane_interventions_total,
+)
+from aura_hive.hive.proteins.guard import GuardSkill
+from aura_hive.hive.proteins.guard.engine import OutputGuard
+
+
+class _Safety:
+    """Minimal stand-in for SafetySettings; the guard reads only these."""
+
+    min_profit_margin = 0.10
+    ui_trigger_price = 1000.0
+    trade_risk_threshold = 0.10
+
+
+def guarded_membrane() -> HiveMembrane:
+    """
+    A Membrane wired the way cortex wires it.
+
+    Worth stating plainly: `inspect_outbound` begins with
+    `if not self.registry: return decision`, so an unwired Membrane passes every
+    price through untouched. A test that forgets the registry tests nothing.
+    """
+    registry = SkillRegistry()
+    guard = GuardSkill()
+    guard.bind(_Safety(), OutputGuard(safety_settings=_Safety()))
+    registry.register(guard.get_name(), guard)
+    return HiveMembrane(registry=registry)
+
+
+def count(direction: str, reason: str) -> float:
+    """Current value of one labelled series, 0.0 before it has ever fired."""
+    value = membrane_interventions_total.labels(
+        direction=direction, reason=reason
+    )._value.get()
+    return float(value)
+
+
+def negotiation_context(floor_price: float = 1000.0) -> Context:
+    return Context(metadata=make_struct({"floor_price": str(floor_price)}))
+
+
+def counter_intent(price: float, message: str = "Here is my offer") -> Intent:
+    return Intent(
+        action=ActionType.ACTION_TYPE_COUNTER,
+        reasoning="LLM reasoning",
+        negotiation=NegotiationIntent(price=price, message=message),
+    )
+
+
+class TestInbound:
+    @pytest.mark.asyncio
+    async def test_a_negative_bid_is_counted(self) -> None:
+        before = count("inbound", "INVALID_BID")
+        membrane = HiveMembrane()
+
+        class Signal:
+            bid_amount = -1.0
+
+        with pytest.raises(ValueError):
+            await membrane.inspect_inbound(Signal())
+
+        assert count("inbound", "INVALID_BID") == before + 1
+
+    @pytest.mark.asyncio
+    async def test_a_clean_signal_counts_nothing(self) -> None:
+        before = count("inbound", "INVALID_BID")
+        membrane = HiveMembrane()
+
+        class Signal:
+            bid_amount = 500.0
+
+        await membrane.inspect_inbound(Signal())
+        assert count("inbound", "INVALID_BID") == before
+
+
+class TestOutbound:
+    @pytest.mark.asyncio
+    async def test_a_price_below_floor_is_counted(self) -> None:
+        """The reason label carries the guard's own code, not a generic string."""
+        membrane = guarded_membrane()
+        before = count("outbound", "FLOOR_PRICE_VIOLATION")
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=500.0), negotiation_context(floor_price=1000.0)
+        )
+
+        # The guard's own error_code, not a generic bucket: an operator wants to
+        # know which invariant fired, not merely that one did.
+        assert count("outbound", "FLOOR_PRICE_VIOLATION") == before + 1
+        assert "Membrane Override" in decision.reasoning
+
+    @pytest.mark.asyncio
+    async def test_a_price_above_floor_counts_nothing(self) -> None:
+        membrane = guarded_membrane()
+        before = count("outbound", "FLOOR_PRICE_VIOLATION")
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=2000.0), negotiation_context(floor_price=1000.0)
+        )
+
+        assert count("outbound", "FLOOR_PRICE_VIOLATION") == before
+        assert "Membrane Override" not in decision.reasoning
+
+    @pytest.mark.asyncio
+    async def test_a_leaked_floor_price_is_counted_separately(self) -> None:
+        """DLP rewrites the message in place; it never went through the override."""
+        membrane = guarded_membrane()
+        before = count("outbound", "DLP_BLOCK")
+
+        await membrane.inspect_outbound(
+            counter_intent(price=2000.0, message="our floor_price is 1000"),
+            negotiation_context(floor_price=1000.0),
+        )
+
+        assert count("outbound", "DLP_BLOCK") == before + 1
+
+
+class TestSeriesShape:
+    def test_direction_and_reason_are_separate_labels(self) -> None:
+        """Aggregating by reason alone would merge an inbound and outbound rate."""
+        sample: Any = membrane_interventions_total.collect()[0].samples[0]
+        assert set(sample.labels) == {"direction", "reason"}
+
+    def test_registering_twice_reuses_the_same_collector(self) -> None:
+        """Tests import this module repeatedly; a duplicate name raises."""
+        from aura_hive.hive.membrane.main import _get_counter
+
+        again = _get_counter("membrane_interventions_total", "ignored", ["x"])
+        assert again is membrane_interventions_total

--- a/core/tests/test_negotiation_history.py
+++ b/core/tests/test_negotiation_history.py
@@ -171,3 +171,87 @@ class TestGroupingApproximation:
 
         history = await cache.get_negotiation_history("did:a", "hotel")
         assert len(history) == 2
+
+
+class TestTransformerSeam:
+    """
+    The boundary the storage tests never crossed.
+
+    Everything above exercises RedisCache directly. That is where the first
+    version of this feature passed twelve tests while returning an empty history
+    every single time: `_as_dict` gives {} for a betterproto Struct, so the
+    protein's answer was discarded on arrival. Parts can all be correct while the
+    seam between them is not.
+    """
+
+    @pytest.mark.asyncio
+    async def test_history_survives_the_protein_boundary(self) -> None:
+        from aura_core.struct_utils import make_struct
+        from aura_core_gen.aura.core.v1 import (
+            Context,
+            HiveContextData,
+            NegotiationOffer,
+            Observation,
+        )
+        from aura_hive.hive.transformer.main import AuraTransformer
+
+        stored = [{"price": 900.0, "membrane_override": False}]
+
+        class Registry:
+            async def execute(
+                self, skill: str, intent: str, params: Any
+            ) -> Observation:
+                assert skill == "persistence"
+                assert intent == "get_negotiation_history"
+                assert params == {"agent_did": "did:key:abc", "item_id": "hotel"}
+                return Observation(
+                    success=True, metadata=make_struct({"history": stored})
+                )
+
+        transformer = AuraTransformer(registry=Registry())  # type: ignore[arg-type]
+        context = Context(
+            hive=HiveContextData(
+                item_identifier="hotel",
+                offer=NegotiationOffer(bid_amount=850.0, agent_did="did:key:abc"),
+            )
+        )
+
+        assert await transformer._load_history(context) == stored
+
+    @pytest.mark.asyncio
+    async def test_a_failing_protein_means_no_history_not_a_failed_deal(self) -> None:
+        from aura_core_gen.aura.core.v1 import (
+            Context,
+            HiveContextData,
+            NegotiationOffer,
+            Observation,
+        )
+        from aura_hive.hive.transformer.main import AuraTransformer
+
+        class Registry:
+            async def execute(self, *_: Any, **__: Any) -> Observation:
+                return Observation(success=False, error="cache_not_initialized")
+
+        transformer = AuraTransformer(registry=Registry())  # type: ignore[arg-type]
+        context = Context(
+            hive=HiveContextData(
+                item_identifier="hotel",
+                offer=NegotiationOffer(bid_amount=850.0, agent_did="did:key:abc"),
+            )
+        )
+
+        assert await transformer._load_history(context) == []
+
+    @pytest.mark.asyncio
+    async def test_a_context_without_an_agent_asks_for_nothing(self) -> None:
+        from aura_core_gen.aura.core.v1 import Context, HiveContextData
+        from aura_hive.hive.transformer.main import AuraTransformer
+
+        class Registry:
+            async def execute(self, *_: Any, **__: Any) -> Any:
+                raise AssertionError("must not query without an agent did")
+
+        transformer = AuraTransformer(registry=Registry())  # type: ignore[arg-type]
+        context = Context(hive=HiveContextData(item_identifier="hotel"))
+
+        assert await transformer._load_history(context) == []

--- a/core/tests/test_negotiation_history.py
+++ b/core/tests/test_negotiation_history.py
@@ -1,0 +1,173 @@
+"""
+Negotiation history: the free phase gets to see its previous passes.
+
+Until this existed `think()` passed `history: []` unconditionally, so every
+round reasoned from scratch. The DSPy signature declared the field all along;
+nothing ever filled it.
+
+Grouping is by (agent_did, item_id) because the wire protocol carries no
+conversation identifier. That is a deliberate approximation, and these tests
+pin down both what it buys and what it costs.
+"""
+
+import json
+from typing import Any
+
+import pytest
+from aura_hive.hive.proteins.persistence.engine import (
+    RedisCache,
+    negotiation_history_key,
+)
+
+
+class FakeRedis:
+    """Enough of redis.asyncio for lists: rpush, ltrim, expire, lrange."""
+
+    def __init__(self) -> None:
+        self.lists: dict[str, list[str]] = {}
+        self.ttls: dict[str, int] = {}
+        self._queued: list[tuple[str, tuple[Any, ...]]] = []
+
+    def pipeline(self) -> "FakeRedis":
+        return self
+
+    def rpush(self, key: str, value: str) -> None:
+        self._queued.append(("rpush", (key, value)))
+
+    def ltrim(self, key: str, start: int, end: int) -> None:
+        self._queued.append(("ltrim", (key, start, end)))
+
+    def expire(self, key: str, ttl: int) -> None:
+        self._queued.append(("expire", (key, ttl)))
+
+    async def execute(self) -> None:
+        for op, args in self._queued:
+            if op == "rpush":
+                self.lists.setdefault(args[0], []).append(args[1])
+            elif op == "ltrim":
+                key, start, end = args
+                items = self.lists.get(key, [])
+                self.lists[key] = items[start:] if end == -1 else items[start : end + 1]
+            elif op == "expire":
+                self.ttls[args[0]] = args[1]
+        self._queued = []
+
+    async def lrange(self, key: str, start: int, end: int) -> list[str]:
+        items = self.lists.get(key, [])
+        return items[start:] if end == -1 else items[start : end + 1]
+
+
+@pytest.fixture
+def cache() -> RedisCache:
+    return RedisCache(FakeRedis())  # type: ignore[arg-type]
+
+
+def turn(price: float, override: bool = False) -> dict[str, Any]:
+    return {
+        "action": "negotiation_counter",
+        "price": price,
+        "membrane_override": override,
+    }
+
+
+class TestKey:
+    def test_the_same_pair_gives_the_same_key(self) -> None:
+        a = negotiation_history_key("did:key:abc", "hotel_alpha")
+        b = negotiation_history_key("did:key:abc", "hotel_alpha")
+        assert a == b
+
+    def test_different_pairs_differ(self) -> None:
+        assert negotiation_history_key("did:a", "x") != negotiation_history_key(
+            "did:b", "x"
+        )
+        assert negotiation_history_key("did:a", "x") != negotiation_history_key(
+            "did:a", "y"
+        )
+
+    def test_a_delimiter_in_a_value_cannot_collide(self) -> None:
+        """`a:b` + `c` and `a` + `b:c` interpolate to the same string."""
+        assert negotiation_history_key("a:b", "c") != negotiation_history_key(
+            "a", "b:c"
+        )
+
+    def test_the_key_is_bounded_regardless_of_input_length(self) -> None:
+        long_did = "did:key:" + "f" * 4000
+        assert len(negotiation_history_key(long_did, "x" * 4000)) < 64
+
+
+class TestRoundTrip:
+    @pytest.mark.asyncio
+    async def test_turns_come_back_oldest_first(self, cache: RedisCache) -> None:
+        for price in (900.0, 950.0, 975.0):
+            await cache.append_negotiation_turn("did:a", "item", turn(price))
+
+        history = await cache.get_negotiation_history("did:a", "item")
+        assert [t["price"] for t in history] == [900.0, 950.0, 975.0]
+
+    @pytest.mark.asyncio
+    async def test_an_untouched_conversation_is_empty_not_an_error(
+        self, cache: RedisCache
+    ) -> None:
+        assert await cache.get_negotiation_history("did:nobody", "item") == []
+
+    @pytest.mark.asyncio
+    async def test_only_the_last_cap_turns_are_kept(self, cache: RedisCache) -> None:
+        """The history ends up inside a prompt; it has to be bounded."""
+        for i in range(30):
+            await cache.append_negotiation_turn("did:a", "item", turn(float(i)), cap=5)
+
+        history = await cache.get_negotiation_history("did:a", "item")
+        assert [t["price"] for t in history] == [25.0, 26.0, 27.0, 28.0, 29.0]
+
+    @pytest.mark.asyncio
+    async def test_a_ttl_is_set_on_every_append(self, cache: RedisCache) -> None:
+        await cache.append_negotiation_turn("did:a", "item", turn(900.0), ttl=1800)
+        key = negotiation_history_key("did:a", "item")
+        assert cache.redis.ttls[key] == 1800  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_a_corrupt_entry_is_skipped_not_fatal(
+        self, cache: RedisCache
+    ) -> None:
+        await cache.append_negotiation_turn("did:a", "item", turn(900.0))
+        key = negotiation_history_key("did:a", "item")
+        cache.redis.lists[key].append("{not json")  # type: ignore[attr-defined]
+        cache.redis.lists[key].append(json.dumps(turn(950.0)))  # type: ignore[attr-defined]
+
+        history = await cache.get_negotiation_history("did:a", "item")
+        assert [t["price"] for t in history] == [900.0, 950.0]
+
+    @pytest.mark.asyncio
+    async def test_the_override_flag_survives_the_round_trip(
+        self, cache: RedisCache
+    ) -> None:
+        """This is the field the eventual measurement reads."""
+        await cache.append_negotiation_turn("did:a", "item", turn(500.0, override=True))
+        history = await cache.get_negotiation_history("did:a", "item")
+        assert history[0]["membrane_override"] is True
+
+
+class TestGroupingApproximation:
+    @pytest.mark.asyncio
+    async def test_conversations_are_separated_by_item(self, cache: RedisCache) -> None:
+        await cache.append_negotiation_turn("did:a", "hotel", turn(900.0))
+        await cache.append_negotiation_turn("did:a", "villa", turn(100.0))
+
+        assert len(await cache.get_negotiation_history("did:a", "hotel")) == 1
+        assert len(await cache.get_negotiation_history("did:a", "villa")) == 1
+
+    @pytest.mark.asyncio
+    async def test_two_deals_for_the_same_item_merge(self, cache: RedisCache) -> None:
+        """
+        The known cost of this design, asserted rather than left implicit.
+
+        With no conversation id on the wire, a second independent negotiation by
+        the same agent over the same item continues the first one's transcript.
+        The TTL bounds how long. Fixing it means adding conversation_id to the
+        proto.
+        """
+        await cache.append_negotiation_turn("did:a", "hotel", turn(900.0))
+        await cache.append_negotiation_turn("did:a", "hotel", turn(200.0))
+
+        history = await cache.get_negotiation_history("did:a", "hotel")
+        assert len(history) == 2


### PR DESCRIPTION
Two prerequisites for measuring how often free reasoning lands somewhere the guarantee has to catch. Neither measures anything yet; together they make the measurement possible for the first time.

## 1. The guard could not say how often it fired

An override rewrote the Intent and left behind a string in a `reasoning` field. DLP edited a message in place. The KYC and risk blocks logged under three different event names. Nothing counted — so the one number that distinguishes a membrane which is earning its place from one that is silently broken was unreadable.

Adds `membrane_interventions_total{direction,reason}` and routes all seven intervention points through one `_record_intervention`: invalid bid and prompt injection inbound; KYC failure, high-risk trade, DLP block and both safe-price overrides outbound.

The `reason` label carries the guard's own `error_code` — `FLOOR_PRICE_VIOLATION` rather than a generic bucket — so an operator learns *which* invariant fired, not merely that one did.

The idempotent-registration helper is duplicated from the telemetry protein rather than imported: the Membrane is a nucleus organ and proteins sit a level below it, so four lines beat an upward dependency.

## 2. The free phase had no memory

`think()` passed `history: []` unconditionally. The DSPy signature has declared the field all along and nothing ever filled it — every round reasoned from scratch. That was an oversight, not a decision, and it meant the reasoning step ran exactly once per deal with no notion of a previous pass.

Turns are now grouped by `(agent_did, item_id)`. The wire protocol carries no conversation identifier — `NegotiateRequest` has `request_id`, `item_id`, `bid_amount`, `currency_code`, `agent`, and `session_token` is derived per request — so there is nothing else to group by.

**The cost of that approximation is real and asserted in the tests rather than left implicit:** two independent negotiations by the same agent over the same item continue one transcript, bounded only by the TTL. Any measurement built on this has to say so. Fixing it properly means adding `conversation_id` to the proto, which is a migration rather than a wiring change.

Storage is a Redis list: `RPUSH` is atomic, so concurrent turns cannot lose each other the way read-modify-write would, and `LTRIM` bounds the prompt this history ends up in. The key is a hash of the pair rather than an interpolation, because a DID or item id may contain the delimiter — `a:b` + `c` and `a` + `b:c` would otherwise collide.

The turn is recorded in the **Connector, after the Membrane**, not in the Transformer. A history of what the model wanted would teach it nothing about what the guard allowed — and each turn carries `membrane_override`, which is the field a per-round measurement reads.

Both paths degrade rather than fail. A cold cache, an unreachable Redis and a first contact all mean "no history", and a negotiation must not fail because its transcript could not be read or written.

## What the tests caught

**`inspect_outbound` opens with `if not self.registry: return decision`.** An unwired Membrane passes every price through untouched. The first version of these tests constructed one without a registry and asserted nothing at all while appearing to pass — the same shape as the bypasses found in #250: a guard that silently does nothing looks exactly like a guard that approved everything. The tests now wire a real `SkillRegistry` and `GuardSkill` the way `cortex` does.

The fail-open behaviour itself is left alone: failing closed would reject every negotiation whenever the registry breaks, and that is a design call rather than a bug fix.

**Three existing transformer tests caught a real bug.** I used `hive.item_id`; the generated field is `item_identifier`. The attribute access sat outside the try, so it escaped as a transformer error instead of degrading to no history. Access now happens inside.

**I guessed a label wrong.** Expected `SAFETY_VIOLATION`; the guard emits `FLOOR_PRICE_VIOLATION`. The test asserts the specific code, which is the stronger claim.

## Still missing before anything can actually be measured

- Working model credentials — both models fail authentication locally.
- A task set harder than the current one: at `success_rate = 1.00` the curve is flat regardless of everything above.

19 new tests, 230 core tests pass; ruff, mypy and bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)