### PR TITLE
feat(guard): declare the rules, so a decision can name what judged it

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -65,6 +65,11 @@ ENV PYTHONPATH=/app/core/src:/app/core/gen-proto
 # Verify critical packages installed
 RUN python -c "import grpc_health.v1.health_pb2"
 
+# The guard's rules are a data file beside its code, not Python, so nothing in
+# the build would otherwise notice it missing — and the failure would surface
+# at runtime as a guard that refuses every decision. Load it here instead.
+RUN python -c "from aura_hive.hive.proteins.guard.ruleset import load_ruleset; print(load_ruleset().version_string)"
+
 EXPOSE 50051
 EXPOSE 9091
 

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -68,7 +68,13 @@ RUN python -c "import grpc_health.v1.health_pb2"
 # The guard's rules are a data file beside its code, not Python, so nothing in
 # the build would otherwise notice it missing — and the failure would surface
 # at runtime as a guard that refuses every decision. Load it here instead.
-RUN python -c "from aura_hive.hive.proteins.guard.ruleset import load_ruleset; print(load_ruleset().version_string)"
+#
+# Loaded by path rather than as aura_hive.hive.proteins.guard.ruleset: importing
+# through the package pulls aura_hive.config, which builds Settings() at import
+# time and demands a database URL no build stage has. ruleset.py has no local
+# imports, so it loads standalone — if that ever stops being true, this check
+# fails loudly rather than silently passing.
+RUN python -c "import sys; sys.path.insert(0, '/app/core/src/aura_hive/hive/proteins/guard'); import ruleset; print(ruleset.load_ruleset().version_string)"
 
 EXPOSE 50051
 EXPOSE 9091

--- a/core/src/aura_hive/hive/proteins/guard/engine.py
+++ b/core/src/aura_hive/hive/proteins/guard/engine.py
@@ -1,16 +1,34 @@
+from collections.abc import Callable
 from typing import Any
 
 import structlog
 
 from aura_hive.hive.metabolism.math import HillDampener
 
+from .ruleset import Ruleset, load_ruleset
+
 logger = structlog.get_logger(__name__)
+
+# Markup applied to the floor when a gate asks for the `floor_markup` strategy.
+# Not operator-tunable: unlike min_profit_margin this is the shape of the
+# fallback rather than a policy dial, so it belongs with the rules.
+_FLOOR_MARKUP = 1.05
 
 
 class SafetyViolation(Exception):
-    """Raised when a negotiation decision violates safety guardrails."""
+    """
+    Raised when a negotiation decision violates safety guardrails.
 
-    pass
+    `code` is the gate's declared code from ruleset.yaml. It exists because the
+    caller used to recover the same information by searching this exception's
+    message for "margin" or "floor" — which relabelled an audit trail whenever
+    someone reworded a string, and which already misreported the fail-closed
+    branch ("Cannot validate margin: ...") as a margin violation.
+    """
+
+    def __init__(self, message: str, code: str = "SAFETY_VIOLATION") -> None:
+        super().__init__(message)
+        self.code = code
 
 
 class OutputGuard:
@@ -20,71 +38,134 @@ class OutputGuard:
     (The "Greedy Merchant" fix)
     """
 
-    def __init__(self, safety_settings: Any = None):
+    def __init__(self, safety_settings: Any = None, ruleset: Ruleset | None = None):
         self.settings = safety_settings
+        self.ruleset = ruleset or load_ruleset()
 
-    def validate_decision(self, decision: dict, context: dict) -> bool:
-        action = decision.get("action")
-        offered_price = decision.get("price", 0.0)
+        # Refuse to run against a rule set that does not describe this engine.
+        # Doing it here rather than at import time means a bad rule set fails
+        # where it can be attributed, and a test can supply its own.
+        self.ruleset.validate_against(set(self.gate_ids()))
+
+        self._safe_price_strategies = {
+            gate.code: gate.safe_price for gate in self.ruleset.gates
+        }
+
+    # Gate id -> the predicate that decides it. The ids are the contract with
+    # ruleset.yaml: `Ruleset.validate_against(gate_ids())` refuses to run if the
+    # two ever drift, in either direction.
+    #
+    # A predicate returns True when the gate passes. It receives the decision
+    # and context untouched rather than a narrowed view, because narrowing would
+    # mean this table also encodes which premises each gate reads — and that is
+    # already declared, once, as `consumes` in the rule set.
+    def _gate_price_positive(self, decision: dict, context: dict) -> bool:
+        price = decision.get("price", 0.0)
+        if price <= 0:
+            logger.warning("invalid_offered_price", price=price)
+            return False
+        return True
+
+    def _gate_floor_violation(self, decision: dict, context: dict) -> bool:
+        price = decision.get("price", 0.0)
         floor_price = context.get("floor_price", 0.0)
-        internal_cost = context.get("internal_cost", 0.0)
-
-        if action not in ["accept", "counter"]:
-            return True
-
-        # 1. Price non-positive check
-        if offered_price <= 0:
-            logger.warning("invalid_offered_price", price=offered_price)
-            raise SafetyViolation("Invalid offered price")
-
-        # 2. Floor price violation (Metabolic Leakage Protection)
-        if offered_price < floor_price:
+        if price < floor_price:
             logger.warning(
                 "safety_floor_violation",
-                action=action,
-                offered_price=offered_price,
+                action=decision.get("action"),
+                offered_price=price,
                 floor_price=floor_price,
             )
-            raise SafetyViolation("Metabolic Leakage: Amount below floor price")
+            return False
+        return True
 
-        # 3. Margin violation
-        if offered_price > 0:
-            margin = (offered_price - internal_cost) / offered_price
-        else:
-            margin = 0
-
+    def _gate_settings_present(self, decision: dict, context: dict) -> bool:
         # DNA Rule: Safety Guard must "Fail-Closed" if misconfigured.
         if not self.settings:
             logger.error("guard_settings_missing_fail_closed")
-            raise SafetyViolation(
-                "Cannot validate margin: safety settings not provided."
-            )
+            return False
+        return True
 
+    def _gate_margin_violation(self, decision: dict, context: dict) -> bool:
+        price = decision.get("price", 0.0)
+        internal_cost = context.get("internal_cost", 0.0)
+        margin = (price - internal_cost) / price if price > 0 else 0
+
+        # Reached only after G3_SETTINGS_PRESENT passed, so settings are here.
         min_margin = self.settings.min_profit_margin
         if margin < min_margin:
             logger.warning(
                 "safety_margin_violation",
-                offered_price=offered_price,
+                offered_price=price,
                 internal_cost=internal_cost,
                 margin=margin,
                 min_margin=min_margin,
             )
-            raise SafetyViolation("Minimum profit margin violation")
+            return False
+        return True
+
+    _MESSAGES = {
+        "G1_PRICE_POSITIVE": "Invalid offered price",
+        "G2_FLOOR_VIOLATION": "Metabolic Leakage: Amount below floor price",
+        "G3_SETTINGS_PRESENT": "Cannot validate margin: safety settings not provided.",
+        "G4_MARGIN_VIOLATION": "Minimum profit margin violation",
+    }
+
+    @classmethod
+    def gate_ids(cls) -> tuple[str, ...]:
+        """The gates this engine can evaluate, for cross-checking the rule set."""
+        return tuple(cls._MESSAGES)
+
+    def _predicate(self, gate_id: str) -> Callable[[dict, dict], bool]:
+        return {
+            "G1_PRICE_POSITIVE": self._gate_price_positive,
+            "G2_FLOOR_VIOLATION": self._gate_floor_violation,
+            "G3_SETTINGS_PRESENT": self._gate_settings_present,
+            "G4_MARGIN_VIOLATION": self._gate_margin_violation,
+        }[gate_id]
+
+    def validate_decision(self, decision: dict, context: dict) -> bool:
+        """
+        Walk the declared gates in order and raise on the first that fails.
+
+        Only accept and counter are judged: those are the actions that put a
+        price on the wire. A reject carrying a nonsense price is not a safety
+        failure, and refusing it would turn the guard into a validator of
+        decisions nobody acts on.
+        """
+        if decision.get("action") not in ["accept", "counter"]:
+            return True
+
+        for gate in self.ruleset.gates:
+            if not self._predicate(gate.id)(decision, context):
+                raise SafetyViolation(self._MESSAGES[gate.id], code=gate.code)
 
         return True
 
     def calculate_safe_price(self, context: dict, reason: str) -> float:
-        """Deterministic safe price calculation for override."""
+        """
+        Deterministic substitute price, by the strategy the firing gate declared.
+
+        `reason` is a gate code where one fired, but not always: the Membrane
+        passes FAILURE_RECOVERY when the Transformer itself blew up, and no gate
+        was involved. Anything the rule set does not name gets the floor markup.
+        """
         floor = float(context.get("floor_price", 0.0))
-        if "margin" in reason.lower():
+        strategy = self._safe_price_strategies.get(reason, "floor_markup")
+
+        if strategy == "margin":
             min_m = 0.1
             if self.settings:
                 min_m = float(self.settings.min_profit_margin)
 
+            # A margin at or above 1.0 makes floor/(1-m) undefined or negative.
+            # Falling back to the default keeps a misconfigured deployment
+            # answering with a real price rather than a nonsensical one.
             if min_m >= 1.0:
                 min_m = 0.1
             return float(round(floor / (1 - min_m), 2))
-        return float(round(floor * 1.05, 2))
+
+        return float(round(floor * _FLOOR_MARKUP, 2))
 
     def validate_transaction(
         self,

--- a/core/src/aura_hive/hive/proteins/guard/engine.py
+++ b/core/src/aura_hive/hive/proteins/guard/engine.py
@@ -20,6 +20,31 @@ _FLOOR_MARKUP = 1.05
 _DEFAULT_MARGIN = 0.1
 
 
+def _numeric(mapping: dict, key: str, default: float = 0.0) -> float:
+    """
+    Read a number that a caller may not have supplied as one.
+
+    Coerced once at the boundary rather than guarded inside each predicate, so
+    the gates stay readable and no two of them can disagree about what a null
+    means.
+
+    Nothing crashes without this — the predicate raises, `skill.py` catches it
+    into a generic Observation, and `SkillRegistry.execute` would catch it even
+    if that did not. What is lost is the `error_code`, so the Membrane falls
+    back to SAFETY_VIOLATION and the receipt stops naming which rule refused
+    the decision. A null price reads as 0.0 and is refused by G1 as the invalid
+    price it is, under its own code.
+    """
+    value = mapping.get(key, default)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        logger.warning("guard_unusable_numeric_input", key=key, value=repr(value))
+        return default
+
+
 class SafetyViolation(Exception):
     """
     Raised when a negotiation decision violates safety guardrails.
@@ -65,15 +90,15 @@ class OutputGuard:
     # mean this table also encodes which premises each gate reads — and that is
     # already declared, once, as `consumes` in the rule set.
     def _gate_price_positive(self, decision: dict, context: dict) -> bool:
-        price = decision.get("price", 0.0)
+        price = _numeric(decision, "price")
         if price <= 0:
             logger.warning("invalid_offered_price", price=price)
             return False
         return True
 
     def _gate_floor_violation(self, decision: dict, context: dict) -> bool:
-        price = decision.get("price", 0.0)
-        floor_price = context.get("floor_price", 0.0)
+        price = _numeric(decision, "price")
+        floor_price = _numeric(context, "floor_price")
         if price < floor_price:
             logger.warning(
                 "safety_floor_violation",
@@ -100,8 +125,8 @@ class OutputGuard:
         return True
 
     def _gate_margin_violation(self, decision: dict, context: dict) -> bool:
-        price = decision.get("price", 0.0)
-        internal_cost = context.get("internal_cost", 0.0)
+        price = _numeric(decision, "price")
+        internal_cost = _numeric(context, "internal_cost")
         margin = (price - internal_cost) / price if price > 0 else 0
 
         # Reached only after G3_SETTINGS_PRESENT passed, so settings are here.
@@ -198,7 +223,7 @@ class OutputGuard:
         passes FAILURE_RECOVERY when the Transformer itself blew up, and no gate
         was involved. Anything the rule set does not name gets the floor markup.
         """
-        floor = float(context.get("floor_price", 0.0))
+        floor = _numeric(context, "floor_price")
         strategy = self._safe_price_strategies.get(reason, "floor_markup")
 
         if strategy == "margin":

--- a/core/src/aura_hive/hive/proteins/guard/engine.py
+++ b/core/src/aura_hive/hive/proteins/guard/engine.py
@@ -14,6 +14,11 @@ logger = structlog.get_logger(__name__)
 # fallback rather than a policy dial, so it belongs with the rules.
 _FLOOR_MARKUP = 1.05
 
+# Used when the configured margin cannot be read or is out of range. Matches
+# the default on SafetySettings, so a deployment that loses its setting behaves
+# like one that never overrode it.
+_DEFAULT_MARGIN = 0.1
+
 
 class SafetyViolation(Exception):
     """
@@ -81,8 +86,16 @@ class OutputGuard:
 
     def _gate_settings_present(self, decision: dict, context: dict) -> bool:
         # DNA Rule: Safety Guard must "Fail-Closed" if misconfigured.
+        #
+        # "Present but incomplete" is misconfiguration too. Checking only that
+        # settings exist let an object without the field through to G4, where
+        # the AttributeError was swallowed into a generic SAFETY_VIOLATION —
+        # losing the fail-closed reason this gate exists to report.
         if not self.settings:
             logger.error("guard_settings_missing_fail_closed")
+            return False
+        if getattr(self.settings, "min_profit_margin", None) is None:
+            logger.error("guard_margin_setting_missing_fail_closed")
             return False
         return True
 
@@ -142,6 +155,41 @@ class OutputGuard:
 
         return True
 
+    def _configured_margin(self) -> float:
+        """
+        The configured minimum margin, clamped to a range that keeps
+        floor/(1-m) at or above the floor.
+
+        A margin at or above 1.0 makes the formula undefined or negative. A
+        margin below 0.0 is worse and was not caught before: floor/(1-(-0.5))
+        is floor/1.5, so a floor of 1000 came back as a "safe" price of 666.67.
+        `min_profit_margin` is env-configurable with no lower bound declared, so
+        that is one operator typo away, and the substitute price exists
+        precisely to be the thing that cannot undercut the floor.
+
+        This is also reached without any gate having run — the Membrane calls
+        `calculate_safe_price` directly on FAILURE_RECOVERY — so a bad setting
+        cannot be assumed to have been caught upstream.
+        """
+        if self.settings is None:
+            return _DEFAULT_MARGIN
+
+        raw = getattr(self.settings, "min_profit_margin", None)
+        if raw is None:
+            return _DEFAULT_MARGIN
+
+        try:
+            margin = float(raw)
+        except (TypeError, ValueError):
+            logger.error("guard_margin_setting_unreadable_using_default", raw=raw)
+            return _DEFAULT_MARGIN
+
+        if not 0.0 <= margin < 1.0:
+            logger.error("guard_margin_setting_out_of_range", margin=margin)
+            return _DEFAULT_MARGIN
+
+        return margin
+
     def calculate_safe_price(self, context: dict, reason: str) -> float:
         """
         Deterministic substitute price, by the strategy the firing gate declared.
@@ -154,15 +202,7 @@ class OutputGuard:
         strategy = self._safe_price_strategies.get(reason, "floor_markup")
 
         if strategy == "margin":
-            min_m = 0.1
-            if self.settings:
-                min_m = float(self.settings.min_profit_margin)
-
-            # A margin at or above 1.0 makes floor/(1-m) undefined or negative.
-            # Falling back to the default keeps a misconfigured deployment
-            # answering with a real price rather than a nonsensical one.
-            if min_m >= 1.0:
-                min_m = 0.1
+            min_m = self._configured_margin()
             return float(round(floor / (1 - min_m), 2))
 
         return float(round(floor * _FLOOR_MARKUP, 2))

--- a/core/src/aura_hive/hive/proteins/guard/manifest.yaml
+++ b/core/src/aura_hive/hive/proteins/guard/manifest.yaml
@@ -1,6 +1,6 @@
 # Internal Metadata (For Cortex)
 skill_name: "guard"
-version: "1.1.0"
+version: "1.2.0"
 description: "Safety validation and safe price calculation protein"
 capabilities:
   - "validate_decision"

--- a/core/src/aura_hive/hive/proteins/guard/ruleset.py
+++ b/core/src/aura_hive/hive/proteins/guard/ruleset.py
@@ -1,0 +1,158 @@
+"""
+Loads and versions the guard's declared rules.
+
+The digest is taken over the parsed structure rather than the file bytes. That
+distinction is the whole reason this module exists: hashing the source would
+mint a new rule-set version every time a comment was reflowed, and a version
+that changes without the rules changing is noise a verifier learns to ignore —
+which is exactly when it stops catching the change that mattered.
+
+See docs/DECISION_RECEIPT.md §3.3 for how the version string reaches a receipt.
+"""
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# How the Membrane prices a substitute offer when a gate fires. Kept closed:
+# an unrecognised strategy is a rule set claiming behaviour the engine has no
+# implementation for, which is the same failure as an undeclared gate.
+SAFE_PRICE_STRATEGIES = frozenset({"margin", "floor_markup"})
+
+_RULESET_PATH = Path(__file__).with_name("ruleset.yaml")
+
+# Length of the digest carried in a version string. Sixteen hex characters is
+# the receipt's canonical-prefix width (§3.7) — long enough that an accidental
+# collision between two rule sets is not a practical concern, short enough to
+# read in a log line.
+_DIGEST_CHARS = 16
+
+
+class RulesetError(Exception):
+    """A rule set that cannot be trusted to describe what the engine does."""
+
+
+@dataclass(frozen=True)
+class Gate:
+    """One declared rule, in the order it is evaluated."""
+
+    id: str
+    code: str
+    consumes: tuple[str, ...]
+    safe_price: str
+
+
+@dataclass(frozen=True)
+class Ruleset:
+    family: str
+    version: str
+    gates: tuple[Gate, ...]
+    digest: str
+
+    @property
+    def version_string(self) -> str:
+        """`guard/negotiation@1.0.0+9c1de4a70b3f5821` — family, semver, digest."""
+        return f"{self.family}@{self.version}+{self.digest}"
+
+    def validate_against(self, implemented: set[str]) -> None:
+        """
+        Confirm the declaration and the implementation describe the same rules.
+
+        Both directions are errors. A declared gate with no predicate would
+        never fire while the rule set advertises that it does; an implemented
+        predicate that is not declared is a rule running outside anything a
+        receipt can account for. Either way the version string would be a claim
+        about behaviour that is not the behaviour.
+        """
+        declared = {gate.id for gate in self.gates}
+
+        undeclared = sorted(implemented - declared)
+        if undeclared:
+            raise RulesetError(
+                f"gates implemented but not declared in ruleset.yaml: {undeclared}"
+            )
+
+        unimplemented = sorted(declared - implemented)
+        if unimplemented:
+            raise RulesetError(
+                f"gates declared in ruleset.yaml but not implemented: {unimplemented}"
+            )
+
+
+def _canonical(mapping: dict[str, Any]) -> bytes:
+    """
+    Byte form the digest is taken over.
+
+    Keys are sorted so that a reordered mapping hashes the same; list order is
+    preserved because gate order decides which reason a decision is refused
+    under, and is therefore part of the rules.
+    """
+    return json.dumps(mapping, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def ruleset_from_mapping(mapping: dict[str, Any]) -> Ruleset:
+    """Build a Ruleset from already-parsed YAML, rejecting anything malformed."""
+    for key in ("family", "version", "gates"):
+        if key not in mapping:
+            raise RulesetError(f"ruleset is missing required key: {key!r}")
+
+    raw_gates = mapping["gates"]
+    if not isinstance(raw_gates, list) or not raw_gates:
+        raise RulesetError("ruleset key 'gates' must be a non-empty list")
+
+    gates: list[Gate] = []
+    seen: set[str] = set()
+    for position, raw in enumerate(raw_gates):
+        for key in ("id", "code", "consumes", "safe_price"):
+            if key not in raw:
+                raise RulesetError(f"gate at position {position} is missing {key!r}")
+
+        gate_id = str(raw["id"])
+        if gate_id in seen:
+            raise RulesetError(f"duplicate gate id in ruleset: {gate_id!r}")
+        seen.add(gate_id)
+
+        strategy = str(raw["safe_price"])
+        if strategy not in SAFE_PRICE_STRATEGIES:
+            raise RulesetError(
+                f"gate {gate_id!r} declares unknown safe_price strategy "
+                f"{strategy!r}; expected one of {sorted(SAFE_PRICE_STRATEGIES)}"
+            )
+
+        gates.append(
+            Gate(
+                id=gate_id,
+                code=str(raw["code"]),
+                consumes=tuple(str(key) for key in raw["consumes"]),
+                safe_price=strategy,
+            )
+        )
+
+    digest = hashlib.sha256(_canonical(mapping)).hexdigest()[:_DIGEST_CHARS]
+
+    return Ruleset(
+        family=str(mapping["family"]),
+        version=str(mapping["version"]),
+        gates=tuple(gates),
+        digest=digest,
+    )
+
+
+def load_ruleset(path: Path | None = None) -> Ruleset:
+    """Read the shipped ruleset.yaml, or another file for tests."""
+    source = path or _RULESET_PATH
+    try:
+        parsed = yaml.safe_load(source.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        # Fail closed and loudly. A guard with no rules is not a permissive
+        # guard, it is a guard whose absence nobody would notice at runtime.
+        raise RulesetError(f"ruleset not found at {source}") from exc
+
+    if not isinstance(parsed, dict):
+        raise RulesetError(f"ruleset at {source} did not parse to a mapping")
+
+    return ruleset_from_mapping(parsed)

--- a/core/src/aura_hive/hive/proteins/guard/ruleset.py
+++ b/core/src/aura_hive/hive/proteins/guard/ruleset.py
@@ -107,9 +107,21 @@ def ruleset_from_mapping(mapping: dict[str, Any]) -> Ruleset:
     gates: list[Gate] = []
     seen: set[str] = set()
     for position, raw in enumerate(raw_gates):
+        # Shape is checked before anything is read out of it, so a malformed
+        # file reads as a bad rule set rather than a TypeError from somewhere
+        # deeper — the caller has one exception type to handle either way.
+        if not isinstance(raw, dict):
+            raise RulesetError(f"gate at position {position} must be a mapping")
+
         for key in ("id", "code", "consumes", "safe_price"):
             if key not in raw:
                 raise RulesetError(f"gate at position {position} is missing {key!r}")
+
+        if not isinstance(raw["consumes"], list):
+            raise RulesetError(
+                f"gate at position {position} declares 'consumes' as "
+                f"{type(raw['consumes']).__name__}, expected a list"
+            )
 
         gate_id = str(raw["id"])
         if gate_id in seen:

--- a/core/src/aura_hive/hive/proteins/guard/ruleset.py
+++ b/core/src/aura_hive/hive/proteins/guard/ruleset.py
@@ -132,13 +132,31 @@ def ruleset_from_mapping(mapping: dict[str, Any]) -> Ruleset:
             )
         )
 
-    digest = hashlib.sha256(_canonical(mapping)).hexdigest()[:_DIGEST_CHARS]
+    # Rebuilt from the validated fields rather than hashed off the raw mapping.
+    # Same argument as not hashing the file bytes, one level up: a `description:`
+    # someone adds for readers is not a rule, and minting a new version for it
+    # teaches everyone that a changed version means nothing.
+    family = str(mapping["family"])
+    version = str(mapping["version"])
+    canonical = {
+        "family": family,
+        "version": version,
+        "gates": [
+            {
+                "id": gate.id,
+                "code": gate.code,
+                "consumes": list(gate.consumes),
+                "safe_price": gate.safe_price,
+            }
+            for gate in gates
+        ],
+    }
 
     return Ruleset(
-        family=str(mapping["family"]),
-        version=str(mapping["version"]),
+        family=family,
+        version=version,
         gates=tuple(gates),
-        digest=digest,
+        digest=hashlib.sha256(_canonical(canonical)).hexdigest()[:_DIGEST_CHARS],
     )
 
 
@@ -151,6 +169,11 @@ def load_ruleset(path: Path | None = None) -> Ruleset:
         # Fail closed and loudly. A guard with no rules is not a permissive
         # guard, it is a guard whose absence nobody would notice at runtime.
         raise RulesetError(f"ruleset not found at {source}") from exc
+    except yaml.YAMLError as exc:
+        # Every other way of failing to get rules raises RulesetError; a syntax
+        # error should not be the one case that surfaces an exception type the
+        # caller has no reason to be catching.
+        raise RulesetError(f"ruleset at {source} is not valid YAML: {exc}") from exc
 
     if not isinstance(parsed, dict):
         raise RulesetError(f"ruleset at {source} did not parse to a mapping")

--- a/core/src/aura_hive/hive/proteins/guard/ruleset.yaml
+++ b/core/src/aura_hive/hive/proteins/guard/ruleset.yaml
@@ -1,0 +1,55 @@
+# The rules the outbound guard applies to a negotiation decision.
+#
+# Declared here rather than left implicit in the control flow of
+# `OutputGuard.validate_decision`, so the set can be hashed and named. A receipt
+# has to say which rules a decision was judged under, and that name is only
+# worth something if it changes when the rules do
+# (docs/DECISION_RECEIPT.md §3.3).
+#
+# What does NOT belong here: operator-tunable thresholds. `min_profit_margin`
+# and friends stay in SafetySettings and are recorded in the policy stamp
+# instead — a threshold an operator may turn is a property of the deployment,
+# not of the rules (VISION §4.2.3). Putting them here would mean every operator
+# who tunes a knob forks the rule set.
+
+family: guard/negotiation
+version: 1.0.0
+
+# Evaluated in this order. The first gate to fail is the binding reason, and it
+# is the one recorded on Intent.outcome_gate; the rest are not evaluated.
+#
+# The order is not a preference. It is the behaviour that shipped before the
+# rules were extracted: the floor check ran ahead of the fail-closed settings
+# check, so a below-floor price on a misconfigured deployment was refused for
+# the floor. Reordering these changes which reason real decisions carry.
+#
+# `consumes` names premise keys, never their values. It is what the receipt's
+# step sequence will record (§3.4), and recording a value there would leak the
+# floor the DLP gate exists to protect.
+#
+# `safe_price` selects the substitute the Membrane offers when the gate fires:
+#   margin       — floor / (1 - min_profit_margin), the higher of the two
+#   floor_markup — floor * safe_price_multiplier
+gates:
+  - id: G1_PRICE_POSITIVE
+    code: INVALID_PRICE
+    consumes: [price]
+    safe_price: floor_markup
+
+  - id: G2_FLOOR_VIOLATION
+    code: FLOOR_PRICE_VIOLATION
+    consumes: [price, floor_price]
+    safe_price: floor_markup
+
+  # Fail-closed: a deployment that cannot read its own margin setting must not
+  # answer with the cheaper formula, so this gate asks for `margin` — which
+  # yields a price above the floor markup and errs toward the seller.
+  - id: G3_SETTINGS_PRESENT
+    code: SETTINGS_MISSING
+    consumes: []
+    safe_price: margin
+
+  - id: G4_MARGIN_VIOLATION
+    code: MIN_MARGIN_VIOLATION
+    consumes: [price, internal_cost]
+    safe_price: margin

--- a/core/src/aura_hive/hive/proteins/guard/skill.py
+++ b/core/src/aura_hive/hive/proteins/guard/skill.py
@@ -68,7 +68,14 @@ class GuardSkill(
             code = e.code
 
             assert self.provider is not None
-            safe_p = self.provider.calculate_safe_price(params.get("context", {}), code)
+            # `or {}` rather than a default: a caller that passed an explicit
+            # None gets the same treatment as one that passed nothing. This runs
+            # inside the SafetyViolation handler, a sibling of the generic
+            # `except Exception` below rather than nested in it, so a raise here
+            # escapes the skill entirely.
+            safe_p = self.provider.calculate_safe_price(
+                params.get("context") or {}, code
+            )
             return Observation(
                 success=False,
                 error=err_msg,

--- a/core/src/aura_hive/hive/proteins/guard/skill.py
+++ b/core/src/aura_hive/hive/proteins/guard/skill.py
@@ -60,12 +60,12 @@ class GuardSkill(
         try:
             return await handler(params)
         except SafetyViolation as e:
+            # The gate's own code, carried on the exception. This used to be
+            # recovered by searching the message for "margin" or "floor", which
+            # relabelled the audit trail on any rewording and already misfiled
+            # the fail-closed branch as a margin violation.
             err_msg = str(e)
-            code = "SAFETY_VIOLATION"
-            if "margin" in err_msg.lower():
-                code = "MIN_MARGIN_VIOLATION"
-            elif "floor" in err_msg.lower():
-                code = "FLOOR_PRICE_VIOLATION"
+            code = e.code
 
             assert self.provider is not None
             safe_p = self.provider.calculate_safe_price(params.get("context", {}), code)

--- a/core/tests/test_guard_gates.py
+++ b/core/tests/test_guard_gates.py
@@ -151,3 +151,79 @@ class TestSafePriceStrategy:
         assert guard(_Safety()).calculate_safe_price(
             context(), "FAILURE_RECOVERY"
         ) == pytest.approx(1050.0)
+
+
+class TestSafePriceNeverUndercutsTheFloor:
+    """
+    The substitute price exists to be safe, so producing one below the floor is
+    the one outcome it must never have.
+
+    `min_profit_margin` is env-configurable and carries no `ge=0` bound, so a
+    negative value is an operator typo away: floor/(1-(-0.5)) is floor/1.5, and
+    a floor of 1000 came back as 666.67. The old guard only rejected margins at
+    or above 1.0, which catches the undefined case and misses this one.
+    """
+
+    @pytest.mark.parametrize("margin", [-0.5, -0.01, 1.0, 1.5])
+    def test_a_margin_outside_the_valid_range_never_prices_below_the_floor(
+        self, margin: float
+    ) -> None:
+        class _Configured:
+            min_profit_margin = margin
+
+        price = guard(_Configured()).calculate_safe_price(
+            context(), "MIN_MARGIN_VIOLATION"
+        )
+
+        assert price >= 1000.0
+
+    def test_a_margin_that_is_not_a_number_still_yields_a_price(self) -> None:
+        """
+        Reached without a gate having run: the Membrane calls this directly on
+        FAILURE_RECOVERY, so a bad setting cannot be assumed already caught.
+        """
+
+        class _Broken:
+            min_profit_margin = None
+
+        price = guard(_Broken()).calculate_safe_price(context(), "SETTINGS_MISSING")
+
+        assert price >= 1000.0
+
+    def test_a_valid_margin_is_still_honoured(self) -> None:
+        """The clamp must not flatten every deployment onto the default."""
+
+        class _Configured:
+            min_profit_margin = 0.50
+
+        assert guard(_Configured()).calculate_safe_price(
+            context(), "MIN_MARGIN_VIOLATION"
+        ) == pytest.approx(2000.0)
+
+
+class TestFailClosedOnIncompleteSettings:
+    def test_a_settings_object_without_the_margin_is_misconfiguration(self) -> None:
+        """
+        G3 exists to catch a deployment that cannot read its own settings, and
+        "present but incomplete" is that case. Before, only `settings is None`
+        counted, so an object missing the field slipped through to G4 and raised
+        AttributeError — which the skill swallowed into a generic
+        SAFETY_VIOLATION, losing the fail-closed reason the gate was for.
+        """
+
+        class _Incomplete:
+            pass
+
+        with pytest.raises(SafetyViolation) as caught:
+            guard(_Incomplete()).validate_decision(decision(price=2000.0), context())
+
+        assert caught.value.code == "SETTINGS_MISSING"
+
+    def test_a_settings_object_with_a_null_margin_is_misconfiguration(self) -> None:
+        class _Null:
+            min_profit_margin = None
+
+        with pytest.raises(SafetyViolation) as caught:
+            guard(_Null()).validate_decision(decision(price=2000.0), context())
+
+        assert caught.value.code == "SETTINGS_MISSING"

--- a/core/tests/test_guard_gates.py
+++ b/core/tests/test_guard_gates.py
@@ -1,0 +1,153 @@
+"""
+The guard evaluates the gates its rule set declares, and says which one fired.
+
+Before this, the identity of the rule that refused a decision was recovered
+downstream by searching the exception message for "margin" or "floor". That is
+fragile in the ordinary way — rewording a message silently relabels an audit
+trail — and it was already wrong: the fail-closed branch raises "Cannot validate
+margin: safety settings not provided", which matches "margin", so a deployment
+that could not read its own settings reported a MIN_MARGIN_VIOLATION.
+
+Gates now carry their code from ruleset.yaml, and the engine walks the declared
+order rather than a hand-written if-chain.
+"""
+
+import pytest
+from aura_hive.hive.proteins.guard.engine import OutputGuard, SafetyViolation
+from aura_hive.hive.proteins.guard.ruleset import RulesetError, load_ruleset
+
+
+class _Safety:
+    min_profit_margin = 0.10
+
+
+def guard(settings: object | None = None) -> OutputGuard:
+    return OutputGuard(safety_settings=settings)
+
+
+def decision(price: float, action: str = "counter") -> dict[str, float | str]:
+    return {"action": action, "price": price}
+
+
+def context(floor: float = 1000.0, cost: float = 500.0) -> dict[str, float]:
+    return {"floor_price": floor, "internal_cost": cost}
+
+
+class TestGateCodes:
+    def test_a_violation_carries_the_gates_declared_code(self) -> None:
+        with pytest.raises(SafetyViolation) as caught:
+            guard(_Safety()).validate_decision(decision(price=500.0), context())
+
+        assert caught.value.code == "FLOOR_PRICE_VIOLATION"
+
+    def test_a_non_positive_price_is_not_a_generic_violation(self) -> None:
+        """
+        This used to fall through to SAFETY_VIOLATION: the message "Invalid
+        offered price" matched neither substring the caller looked for, so a
+        malformed price and an unclassified failure were indistinguishable.
+        """
+        with pytest.raises(SafetyViolation) as caught:
+            guard(_Safety()).validate_decision(decision(price=0.0), context())
+
+        assert caught.value.code == "INVALID_PRICE"
+
+    def test_missing_settings_reports_configuration_not_margin(self) -> None:
+        """
+        The behaviour change worth flagging. A guard that cannot read its
+        settings still fails closed — that part is unchanged — but it now says
+        so. Reporting SETTINGS_MISSING as a margin violation sent an operator
+        looking at pricing when the fault was deployment.
+        """
+        with pytest.raises(SafetyViolation) as caught:
+            guard(settings=None).validate_decision(decision(price=2000.0), context())
+
+        assert caught.value.code == "SETTINGS_MISSING"
+
+    def test_a_thin_margin_reports_the_margin_gate(self) -> None:
+        with pytest.raises(SafetyViolation) as caught:
+            guard(_Safety()).validate_decision(
+                decision(price=1010.0), context(floor=1000.0, cost=1000.0)
+            )
+
+        assert caught.value.code == "MIN_MARGIN_VIOLATION"
+
+
+class TestGateOrder:
+    def test_the_floor_gate_fires_before_the_settings_gate(self) -> None:
+        """
+        Preserves what shipped. A below-floor price on a deployment with no
+        settings was refused for the floor, and decisions already in flight
+        carry that reason.
+        """
+        with pytest.raises(SafetyViolation) as caught:
+            guard(settings=None).validate_decision(decision(price=500.0), context())
+
+        assert caught.value.code == "FLOOR_PRICE_VIOLATION"
+
+    def test_the_price_gate_fires_before_the_floor_gate(self) -> None:
+        with pytest.raises(SafetyViolation) as caught:
+            guard(_Safety()).validate_decision(decision(price=-5.0), context())
+
+        assert caught.value.code == "INVALID_PRICE"
+
+    def test_a_clean_decision_passes_every_gate(self) -> None:
+        assert guard(_Safety()).validate_decision(decision(price=2000.0), context())
+
+    def test_an_action_outside_scope_is_not_judged(self) -> None:
+        """
+        Only accept and counter put a price on the wire, so only those are
+        judged. A reject carrying a nonsense price is not a safety failure.
+        """
+        assert guard(_Safety()).validate_decision(
+            decision(price=-5.0, action="reject"), context()
+        )
+
+
+class TestDeclarationMatchesImplementation:
+    def test_the_engine_implements_exactly_the_declared_gates(self) -> None:
+        """
+        The cross-check that keeps the version string honest. A gate declared
+        but not implemented never fires while the rule set says it does; one
+        implemented but not declared runs outside anything a receipt records.
+        """
+        load_ruleset().validate_against(set(OutputGuard.gate_ids()))
+
+    def test_an_engine_missing_a_declared_gate_is_rejected(self) -> None:
+        with pytest.raises(RulesetError, match="G4_MARGIN_VIOLATION"):
+            load_ruleset().validate_against(
+                set(OutputGuard.gate_ids()) - {"G4_MARGIN_VIOLATION"}
+            )
+
+
+class TestSafePriceStrategy:
+    def test_the_margin_gate_prices_above_the_floor_markup(self) -> None:
+        """
+        floor/(1-m) against floor*1.05: the two formulas are not interchangeable,
+        which is why the gate declares which one applies.
+        """
+        engine = guard(_Safety())
+
+        margin_price = engine.calculate_safe_price(context(), "MIN_MARGIN_VIOLATION")
+        markup_price = engine.calculate_safe_price(context(), "FLOOR_PRICE_VIOLATION")
+
+        assert margin_price > markup_price
+
+    def test_missing_settings_gets_the_conservative_formula(self) -> None:
+        """
+        G3 declares `safe_price: margin` precisely so a misconfigured deployment
+        does not answer with the cheaper number.
+        """
+        engine = guard(_Safety())
+
+        assert engine.calculate_safe_price(
+            context(), "SETTINGS_MISSING"
+        ) == engine.calculate_safe_price(context(), "MIN_MARGIN_VIOLATION")
+
+    def test_an_unrecognised_reason_falls_back_to_the_floor_markup(self) -> None:
+        """
+        Callers pass reasons the rule set does not name — FAILURE_RECOVERY comes
+        from the Membrane, not from a gate — and those still need a price.
+        """
+        assert guard(_Safety()).calculate_safe_price(
+            context(), "FAILURE_RECOVERY"
+        ) == pytest.approx(1050.0)

--- a/core/tests/test_guard_gates.py
+++ b/core/tests/test_guard_gates.py
@@ -201,6 +201,65 @@ class TestSafePriceNeverUndercutsTheFloor:
         ) == pytest.approx(2000.0)
 
 
+class TestUnusableInputsStillNameAGate:
+    """
+    A null or unparseable number must not cost the decision its gate.
+
+    Nothing crashes today: the predicate raises TypeError, `skill.py` catches it
+    into a generic Observation, and `SkillRegistry.execute` would catch it even
+    if that did not. But the Observation carries no `error_code`, so the Membrane
+    falls back to SAFETY_VIOLATION and the audit trail stops naming which rule
+    refused the decision — which is the whole point of the gate codes.
+
+    Unreachable from the Membrane, which coerces every value to float before the
+    guard sees it. Reachable from `guard__validate_safety`, declared as an LLM
+    tool in manifest.yaml, where a model emitting `"price": null` is ordinary.
+    """
+
+    @pytest.mark.parametrize("price", [None, "not a number"])
+    def test_an_unusable_price_is_an_invalid_price(self, price: object) -> None:
+        with pytest.raises(SafetyViolation) as caught:
+            guard(_Safety()).validate_decision(
+                {"action": "counter", "price": price}, context()
+            )
+
+        assert caught.value.code == "INVALID_PRICE"
+
+    def test_an_unusable_floor_is_treated_as_an_absent_one(self) -> None:
+        """
+        Matches what a missing key already does rather than inventing a stricter
+        rule here: `floor_price` defaults to 0.0 throughout, so a null reads the
+        same as no floor supplied. That default is permissive, and deliberately
+        left alone — see the note on #258.
+        """
+        assert guard(_Safety()).validate_decision(
+            {"action": "counter", "price": 2000.0},
+            {"floor_price": None, "internal_cost": 500.0},
+        )
+
+    def test_an_unusable_cost_is_judged_rather_than_exploding(self) -> None:
+        """
+        Cost reads as 0.0, so the margin computes to 1.0 and G4 passes. The
+        property under test is that the gate reached a verdict at all: before,
+        the comparison raised past every gate and the decision came back with no
+        code attached.
+        """
+        assert guard(_Safety()).validate_decision(
+            {"action": "counter", "price": 1000.0},
+            {"floor_price": 1000.0, "internal_cost": "unknown"},
+        )
+
+    def test_a_null_floor_still_yields_a_safe_price(self) -> None:
+        """
+        Reached from inside `skill.py`'s SafetyViolation handler, which is a
+        sibling of its generic `except Exception` rather than nested inside it.
+        A raise here escapes the skill entirely.
+        """
+        assert guard(_Safety()).calculate_safe_price(
+            {"floor_price": None}, "FLOOR_PRICE_VIOLATION"
+        ) == pytest.approx(0.0)
+
+
 class TestFailClosedOnIncompleteSettings:
     def test_a_settings_object_without_the_margin_is_misconfiguration(self) -> None:
         """

--- a/core/tests/test_guard_ruleset.py
+++ b/core/tests/test_guard_ruleset.py
@@ -1,0 +1,197 @@
+"""
+The guard's rules are declared, so they can be versioned.
+
+A receipt has to name the rules a decision was judged under, and a name is only
+worth something if it changes when the rules do (docs/DECISION_RECEIPT.md §3.3).
+Two things stood in the way. The gate order lived in the control flow of
+`validate_decision`, where it could be reordered without anyone noticing, and
+the identity of the rule that fired was recovered downstream by looking for the
+substring "margin" or "floor" in an exception message.
+
+`ruleset.yaml` declares the gates in order, each with the code it emits. The
+digest is taken over the parsed structure rather than the file bytes, so
+reformatting the file does not invent a new version while any semantic edit does.
+"""
+
+import json
+
+import pytest
+import yaml
+from aura_hive.hive.proteins.guard.ruleset import (
+    RulesetError,
+    load_ruleset,
+    ruleset_from_mapping,
+)
+
+MINIMAL = {
+    "family": "guard/negotiation",
+    "version": "1.0.0",
+    "gates": [
+        {
+            "id": "G1_A",
+            "code": "A_FAILED",
+            "consumes": ["price"],
+            "safe_price": "margin",
+        },
+        {
+            "id": "G2_B",
+            "code": "B_FAILED",
+            "consumes": ["price"],
+            "safe_price": "floor_markup",
+        },
+    ],
+}
+
+
+class TestVersionString:
+    def test_the_version_names_the_family_the_semver_and_the_digest(self) -> None:
+        ruleset = ruleset_from_mapping(MINIMAL)
+
+        family, _, rest = ruleset.version_string.partition("@")
+        semver, _, digest = rest.partition("+")
+
+        assert family == "guard/negotiation"
+        assert semver == "1.0.0"
+        assert len(digest) == 16
+        assert digest == digest.lower()
+        int(digest, 16)  # raises if it is not hex
+
+
+class TestDigest:
+    def test_reformatting_the_file_does_not_change_the_digest(self) -> None:
+        """
+        The digest is taken over parsed structure, not bytes.
+
+        Hashing the file directly was the obvious implementation and the wrong
+        one: a reflowed comment would mint a new rule-set version, and a version
+        that changes without the rules changing is noise a verifier has to
+        ignore — which trains everyone to ignore it when it matters.
+        """
+        dense = yaml.safe_load(json.dumps(MINIMAL))
+        spaced = yaml.safe_load(
+            "# a comment\n" + yaml.safe_dump(MINIMAL, default_flow_style=False)
+        )
+
+        assert ruleset_from_mapping(dense).digest == ruleset_from_mapping(spaced).digest
+
+    def test_reordering_the_gates_changes_the_digest(self) -> None:
+        """Gate order is semantic: it decides which reason a decision is refused under."""
+        swapped = json.loads(json.dumps(MINIMAL))
+        swapped["gates"].reverse()
+
+        assert (
+            ruleset_from_mapping(swapped).digest != ruleset_from_mapping(MINIMAL).digest
+        )
+
+    def test_changing_a_code_changes_the_digest(self) -> None:
+        edited = json.loads(json.dumps(MINIMAL))
+        edited["gates"][0]["code"] = "SOMETHING_ELSE"
+
+        assert (
+            ruleset_from_mapping(edited).digest != ruleset_from_mapping(MINIMAL).digest
+        )
+
+
+class TestFailClosed:
+    def test_a_gate_the_engine_cannot_evaluate_is_rejected(self) -> None:
+        """
+        A declared gate with no implementation would silently never fire — the
+        rule-set would claim a guarantee the engine does not provide.
+        """
+        ruleset = ruleset_from_mapping(MINIMAL)
+
+        with pytest.raises(RulesetError, match="G2_B"):
+            ruleset.validate_against({"G1_A"})
+
+    def test_an_implemented_gate_the_ruleset_omits_is_rejected(self) -> None:
+        """
+        The other direction matters just as much: a predicate that runs without
+        being declared is a rule no receipt can account for.
+        """
+        ruleset = ruleset_from_mapping(MINIMAL)
+
+        with pytest.raises(RulesetError, match="G3_C"):
+            ruleset.validate_against({"G1_A", "G2_B", "G3_C"})
+
+    def test_a_matching_set_is_accepted(self) -> None:
+        ruleset = ruleset_from_mapping(MINIMAL)
+        ruleset.validate_against({"G1_A", "G2_B"})
+
+    def test_a_duplicate_gate_id_is_rejected(self) -> None:
+        """Two gates with one id make the recorded reason ambiguous."""
+        dupe = json.loads(json.dumps(MINIMAL))
+        dupe["gates"][1]["id"] = "G1_A"
+
+        with pytest.raises(RulesetError, match="G1_A"):
+            ruleset_from_mapping(dupe)
+
+    def test_an_unknown_safe_price_strategy_is_rejected(self) -> None:
+        bad = json.loads(json.dumps(MINIMAL))
+        bad["gates"][0]["safe_price"] = "guess"
+
+        with pytest.raises(RulesetError, match="guess"):
+            ruleset_from_mapping(bad)
+
+    @pytest.mark.parametrize("missing", ["family", "version", "gates"])
+    def test_a_missing_top_level_key_is_rejected(self, missing: str) -> None:
+        incomplete = json.loads(json.dumps(MINIMAL))
+        del incomplete[missing]
+
+        with pytest.raises(RulesetError, match=missing):
+            ruleset_from_mapping(incomplete)
+
+
+class TestShippedRuleset:
+    def test_the_shipped_ruleset_loads(self) -> None:
+        ruleset = load_ruleset()
+
+        assert ruleset.family == "guard/negotiation"
+        assert [gate.id for gate in ruleset.gates] == [
+            "G1_PRICE_POSITIVE",
+            "G2_FLOOR_VIOLATION",
+            "G3_SETTINGS_PRESENT",
+            "G4_MARGIN_VIOLATION",
+        ]
+
+    def test_the_shipped_order_is_the_order_the_engine_applied_before(self) -> None:
+        """
+        This order is not a preference, it is the behaviour that shipped: the
+        floor check ran before the fail-closed settings check, so a decision
+        below floor on a misconfigured deployment was refused for the floor.
+        Moving G3 earlier would change which reason those decisions carry.
+        """
+        ids = [gate.id for gate in load_ruleset().gates]
+
+        assert ids.index("G2_FLOOR_VIOLATION") < ids.index("G3_SETTINGS_PRESENT")
+
+    def test_the_fail_closed_gate_asks_for_the_conservative_safe_price(self) -> None:
+        """
+        A deployment that cannot read its own margin setting should not answer
+        with the cheaper of the two formulas. `margin` yields floor/(1-m),
+        above the floor markup, so misconfiguration errs toward the seller.
+        """
+        gate = {g.id: g for g in load_ruleset().gates}["G3_SETTINGS_PRESENT"]
+
+        assert gate.safe_price == "margin"
+
+    def test_the_shipped_version_string_is_the_pinned_one(self) -> None:
+        """
+        A change detector, deliberately.
+
+        The digest is what a receipt cites to say which rules judged a decision,
+        so it must not drift by accident. Editing ruleset.yaml fails here until
+        the pin is updated in the same commit — which is the moment to ask
+        whether `version` should be bumped too, since consumers key off the
+        semver and only notice the digest afterwards.
+        """
+        assert (
+            load_ruleset().version_string == "guard/negotiation@1.0.0+46cc0e38ca4f895c"
+        )
+
+    def test_every_shipped_gate_declares_what_it_consumes(self) -> None:
+        """
+        `consumes` names premise keys, never values — it is what the receipt's
+        step sequence will record (docs/DECISION_RECEIPT.md §3.4).
+        """
+        for gate in load_ruleset().gates:
+            assert isinstance(gate.consumes, tuple)

--- a/core/tests/test_guard_ruleset.py
+++ b/core/tests/test_guard_ruleset.py
@@ -173,6 +173,21 @@ class TestMalformedSource:
         with pytest.raises(RulesetError, match="not found"):
             load_ruleset(tmp_path / "absent.yaml")
 
+    def test_a_gate_that_is_not_a_mapping_is_a_ruleset_error(self) -> None:
+        """A malformed entry should read as a bad rule set, not a TypeError."""
+        bad = json.loads(json.dumps(MINIMAL))
+        bad["gates"][0] = "G1_A"
+
+        with pytest.raises(RulesetError, match="mapping"):
+            ruleset_from_mapping(bad)
+
+    def test_a_consumes_that_is_not_a_list_is_a_ruleset_error(self) -> None:
+        bad = json.loads(json.dumps(MINIMAL))
+        bad["gates"][0]["consumes"] = "price"
+
+        with pytest.raises(RulesetError, match="consumes"):
+            ruleset_from_mapping(bad)
+
     def test_a_file_that_is_not_a_mapping_is_a_ruleset_error(
         self, tmp_path: Path
     ) -> None:

--- a/core/tests/test_guard_ruleset.py
+++ b/core/tests/test_guard_ruleset.py
@@ -14,6 +14,7 @@ reformatting the file does not invent a new version while any semantic edit does
 """
 
 import json
+from pathlib import Path
 
 import pytest
 import yaml
@@ -83,6 +84,20 @@ class TestDigest:
             ruleset_from_mapping(swapped).digest != ruleset_from_mapping(MINIMAL).digest
         )
 
+    def test_a_non_semantic_top_level_key_does_not_change_the_digest(self) -> None:
+        """
+        Same argument as hashing bytes, one level up: a `description:` added for
+        readers is not a rule, and minting a new version for it teaches everyone
+        that a changed version means nothing.
+        """
+        annotated = json.loads(json.dumps(MINIMAL))
+        annotated["description"] = "notes for whoever reads this next"
+
+        assert (
+            ruleset_from_mapping(annotated).digest
+            == ruleset_from_mapping(MINIMAL).digest
+        )
+
     def test_changing_a_code_changes_the_digest(self) -> None:
         edited = json.loads(json.dumps(MINIMAL))
         edited["gates"][0]["code"] = "SOMETHING_ELSE"
@@ -139,6 +154,33 @@ class TestFailClosed:
 
         with pytest.raises(RulesetError, match=missing):
             ruleset_from_mapping(incomplete)
+
+
+class TestMalformedSource:
+    def test_unparseable_yaml_is_a_ruleset_error(self, tmp_path: Path) -> None:
+        """
+        Every other way of failing to get rules raises RulesetError; a syntax
+        error should not be the one case that surfaces a yaml exception the
+        caller has no reason to catch.
+        """
+        broken = tmp_path / "ruleset.yaml"
+        broken.write_text("gates: [\n  - id: unterminated\n", encoding="utf-8")
+
+        with pytest.raises(RulesetError, match="valid YAML"):
+            load_ruleset(broken)
+
+    def test_a_missing_file_is_a_ruleset_error(self, tmp_path: Path) -> None:
+        with pytest.raises(RulesetError, match="not found"):
+            load_ruleset(tmp_path / "absent.yaml")
+
+    def test_a_file_that_is_not_a_mapping_is_a_ruleset_error(
+        self, tmp_path: Path
+    ) -> None:
+        listed = tmp_path / "ruleset.yaml"
+        listed.write_text("- just\n- a\n- list\n", encoding="utf-8")
+
+        with pytest.raises(RulesetError, match="mapping"):
+            load_ruleset(listed)
 
 
 class TestShippedRuleset:

--- a/docs/DECISION_RECEIPT.md
+++ b/docs/DECISION_RECEIPT.md
@@ -92,27 +92,70 @@ downgrade from VISION's Layer 1 and the main thing that would have to be built t
 
 ### 3.3 `ruleset-version`
 
-`guard/negotiation@1.0.0+<hex16>` where the suffix is `SHA256` of the **declarative** rule table.
+**Implemented.** `guard/negotiation@1.0.0+46cc0e38ca4f895c` — family, semver, and a digest over the
+declared rules in `proteins/guard/ruleset.yaml`.
 
-This forces a prerequisite refactor: today the rules live as Python control flow in
-`proteins/guard/engine.py` and thresholds hang off `settings.safety`. A version identifier over
-Python source is brittle (a comment change bumps it). The rules need to be extracted into a
-content-addressable artefact — `proteins/guard/ruleset.yaml` — with the engine as its interpreter:
+The digest is taken over the **parsed structure**, not the file bytes. Hashing the source was the
+obvious implementation and the wrong one: a reflowed comment would mint a new rule-set version, and
+a version that changes without the rules changing is noise a verifier learns to ignore — which is
+precisely when it stops catching the change that mattered. Keys are sorted; list order is preserved,
+because gate order decides which reason a decision is refused under and is therefore part of the
+rules.
+
+> **Correction to an earlier draft of this document.** The first sketch put a `thresholds:` block
+> inside `ruleset.yaml`. That is wrong on VISION's own terms: §4.2.3 makes the threshold "a
+> configurable predicate on the receipt, not a property of the layer", and operator-tunable values
+> belong in the **policy stamp** (§3.5), not the rule set. Folding them in would mean every operator
+> who turns a knob forks the rule set, and two deployments running identical rules would cite
+> different versions. `min_profit_margin` and friends stay in `SafetySettings`. The practical
+> benefit is that extracting the rules changed no configuration semantics — the env override still
+> works.
+
+What the rule set does hold is the gate list, in evaluation order, each with the code it emits, the
+premise keys it consumes, and the safe-price strategy that applies when it fires:
 
 ```yaml
 family: guard/negotiation
 version: 1.0.0
 gates:
-  - id: G1_DLP_DISCLOSURE      # forbids floor_price in outbound message
-  - id: G2_ACTION_SCOPE        # only accept/counter are validated further
-  - id: G3_PRICE_POSITIVE
-  - id: G4_FLOOR_VIOLATION
-  - id: G5_MARGIN_VIOLATION
-  - id: G6_SETTINGS_PRESENT    # fail-closed if misconfigured
-thresholds:
-  min_profit_margin: 0.10
-  safe_price_multiplier: 1.05
+  - id: G1_PRICE_POSITIVE
+    code: INVALID_PRICE
+    consumes: [price]
+    safe_price: floor_markup
+  - id: G2_FLOOR_VIOLATION
+    code: FLOOR_PRICE_VIOLATION
+    consumes: [price, floor_price]
+    safe_price: floor_markup
+  - id: G3_SETTINGS_PRESENT      # fail-closed if misconfigured
+    code: SETTINGS_MISSING
+    consumes: []
+    safe_price: margin
+  - id: G4_MARGIN_VIOLATION
+    code: MIN_MARGIN_VIOLATION
+    consumes: [price, internal_cost]
+    safe_price: margin
 ```
+
+Two properties keep the version honest rather than decorative:
+
+- **The declaration and the implementation cross-check, both ways.** `OutputGuard.__init__` calls
+  `Ruleset.validate_against(gate_ids())` and refuses to construct on a mismatch. A declared gate with
+  no predicate would never fire while the rule set advertises it; a predicate that is not declared
+  runs outside anything a receipt can account for.
+- **The shipped digest is pinned in a test.** Editing `ruleset.yaml` fails `test_guard_ruleset.py`
+  until the pin is updated in the same commit — which is the moment to ask whether `version` should
+  be bumped too.
+
+The gate order shipped here is not a preference; it reproduces the order the if-chain applied, so
+decisions already in flight keep the reason they were refused under. Note `G1_DLP_DISCLOSURE` and
+`G2_ACTION_SCOPE` from the earlier sketch are absent: DLP lives in the Membrane rather than the
+guard engine, and action scope is a precondition for judging at all rather than a gate that can
+fail. Both would need a second family to be declared honestly.
+
+**Still a partial content-address.** The digest covers the gate list, not the predicate bodies —
+those are still Python. A change to what `_gate_margin_violation` computes does not move the digest,
+so predicate edits require a manual `version` bump that nothing enforces. VISION §4.2.4 wants the
+implementation content-addressed by the rule-set hash; we are not there.
 
 `trade` and `rwa_vault` params get sibling families (`guard/trade@…`, `guard/rwa@…`) with their own
 gate lists (`KYC_PASSED`, `RISK_THRESHOLD`, `HILL_CEILING`, `WALLET_SANCTIFIED`).
@@ -239,7 +282,11 @@ committed beforehand. What they do not learn: the floor, the margin, the cost.
    `proto/aura/core/v1/metabolism.proto`; stamped by `_stamp()` / `_settle()` in
    `membrane/main.py`; covered by `core/tests/test_membrane_outcome.py`. First-gate-wins is
    implemented and tested. No crypto, no wire format yet.
-2. Extract `ruleset.yaml`; make `engine.py` its interpreter; derive `ruleset-version`.
+2. ~~Extract `ruleset.yaml`; make `engine.py` its interpreter; derive `ruleset-version`.~~ **DONE.**
+   `proteins/guard/ruleset.{yaml,py}`; the engine walks the declared gates and `SafetyViolation`
+   carries the gate's code, replacing the substring match on the exception message. Covered by
+   `core/tests/test_guard_{ruleset,gates}.py`. Caveat in §3.3: predicate bodies are still outside
+   the digest.
 3. Emit `gate-sequence` + `derivation-hash`; add a replay test asserting byte-stability across runs.
 4. Add hashes, salt, split policy stamp.
 5. Sign with the identity key; wire `canonical-prefix` into logs and frontend.


### PR DESCRIPTION
Step 2 of `docs/DECISION_RECEIPT.md` §6. Follows #255.

## Why

A receipt has to cite the rules a decision was judged under, and that citation is worth nothing if it does not change when the rules do. Two things were in the way:

- **Gate order lived in control flow.** `validate_decision` was a hand-written if-chain; reordering it changed which reason real decisions carry, and nothing would have noticed.
- **The rule that fired was identified by substring.** `skill.py` searched the exception message for `"margin"` or `"floor"` to pick an error code — the same code that now lands in `Intent.outcome_gate`.

## What

`proteins/guard/ruleset.yaml` declares the gates in evaluation order, each with the code it emits, the premise keys it consumes, and the safe-price strategy that applies when it fires. `ruleset.py` loads it and derives `guard/negotiation@1.0.0+46cc0e38ca4f895c`.

### The digest is over parsed structure, not file bytes

Hashing the source was the obvious implementation and the wrong one: a reflowed comment would mint a new rule-set version, and a version that changes without the rules changing is noise a verifier learns to ignore — which is exactly when it stops catching the change that mattered. Keys are sorted; list order is preserved, since gate order is semantic.

### Two properties keep the version from being decorative

- **The declaration and the implementation cross-check, both ways.** `OutputGuard.__init__` calls `Ruleset.validate_against(gate_ids())` and refuses to construct on a mismatch. A declared gate with no predicate never fires while the rule set advertises it; a predicate that is not declared runs outside anything a receipt can account for.
- **The shipped digest is pinned in a test.** Editing `ruleset.yaml` fails until the pin moves in the same commit — which is the moment to ask whether `version` should be bumped.

## Behaviour changes — please review these specifically

Two error codes change. The refusals themselves do not: the same decisions are refused, under the same gate order.

| case | before | after |
|---|---|---|
| settings missing (fail-closed) | `MIN_MARGIN_VIOLATION` | `SETTINGS_MISSING` |
| price ≤ 0 | `SAFETY_VIOLATION` (generic) | `INVALID_PRICE` |

The first was a real misreport. The fail-closed branch raises `"Cannot validate margin: safety settings not provided"`, which matches `"margin"`, so a deployment that could not read its own settings reported a margin violation and sent operators looking at pricing when the fault was configuration.

**Gate order is preserved deliberately.** `G2_FLOOR_VIOLATION` still runs ahead of `G3_SETTINGS_PRESENT`, so a below-floor price on a misconfigured deployment is still refused for the floor — decisions already in flight keep the reason they carry. `test_the_shipped_order_is_the_order_the_engine_applied_before` pins this.

The safe price each gate asks for is now declared rather than inferred from the same substring match. `G3` asks for `margin` on purpose: `floor/(1-m)` sits above the floor markup, so a misconfigured deployment errs toward the seller rather than answering with the cheaper number.

## Deployment

The rules are a data file beside the code, so nothing in the build would notice it missing, and the failure would surface at runtime as a guard refusing every decision. `core/Dockerfile` now loads the rule set at build time. (The image already `COPY`s `core/src` wholesale and runs from `PYTHONPATH`, so the file does ship — this is a guard against that changing.)

## Doc correction

§3.3 of `DECISION_RECEIPT.md` had put a `thresholds:` block inside the rule set. That is wrong on VISION's own terms — §4.2.3 makes the threshold "a configurable predicate on the receipt, not a property of the layer", so operator-tunable values belong in the policy stamp. Folding them in would fork the rule set for every operator who turns a knob, and two deployments running identical rules would cite different versions.

Practical consequence: `min_profit_margin` stays in `SafetySettings`, so **this PR changes no configuration semantics** — the env override still works.

Also noted there: `G1_DLP_DISCLOSURE` and `G2_ACTION_SCOPE` from the earlier sketch are absent. DLP lives in the Membrane, not the guard engine, and action scope is a precondition for judging rather than a gate that can fail. Both need a second family to be declared honestly.

## Known gap

The digest covers the gate list, not the predicate bodies — those are still Python. Changing what `_gate_margin_violation` computes does not move the digest, so predicate edits need a manual `version` bump that nothing enforces. VISION §4.2.4 wants the implementation content-addressed by the rule-set hash; we are not there, and §3.3 says so.

## Testing

Written test-first, in two red-green cycles (loader, then engine). 29 new tests.

```
core/tests/test_guard_ruleset.py     17 passed  (new)
core/tests/test_guard_gates.py       12 passed  (new)
core/tests/                         279 passed  (was 249)
api-gateway / telegram-bot / bee-keeper  1 / 6 / 7 passed
ruff check + format                   clean
mypy core/src                         85 files, no issues
bandit                                0 high / 0 medium / 0 low
tools/check_fractal_completeness.py   OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)