### PR TITLE
feat(guard): record how the verdict was reached, not just what it was

### DIFF
--- a/core/src/aura_hive/hive/membrane/main.py
+++ b/core/src/aura_hive/hive/membrane/main.py
@@ -111,8 +111,12 @@ def _attach_derivation(decision: Intent, obs_meta: dict[str, Any]) -> Intent:
     declared in a rule set yet. Attaching an empty digest there would assert a
     derivation that never happened, which is worse than saying nothing.
     """
-    sequence = str(obs_meta.get("gate_sequence", ""))
-    digest = str(obs_meta.get("derivation_hash", ""))
+    # `or ""` rather than a default, because `str(None)` is "None" — truthy, and
+    # it would attach a record whose sequence is that literal text and whose
+    # hash claims a derivation that never ran. A Struct round-trips a null value
+    # back as None, so a key being present is not the same as it carrying one.
+    sequence = str(obs_meta.get("gate_sequence") or "")
+    digest = str(obs_meta.get("derivation_hash") or "")
     if sequence or digest:
         decision.derivation = DecisionDerivation(
             gate_sequence=sequence, derivation_hash=digest
@@ -381,7 +385,13 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
             },
         )
 
-        obs_meta = obs.metadata.to_dict()
+        # A default-constructed Observation always has an empty Struct here, so
+        # this is not the usual betterproto caution — but `metadata=None` is a
+        # legal way to build one, and this read moved onto the passing path in
+        # the same change that added the derivation. It had only ever run on the
+        # failing path before. A crash here would lose the negotiation inside
+        # the one component whose job is to never let a bad decision out.
+        obs_meta = obs.metadata.to_dict() if obs.metadata is not None else {}
 
         # Attached to the Intent the guard judged, before any replacement is
         # built, so `_replacing` carries it across the swap like the rest of the

--- a/core/src/aura_hive/hive/membrane/main.py
+++ b/core/src/aura_hive/hive/membrane/main.py
@@ -6,6 +6,7 @@ from aura_core import Membrane, SkillRegistry, make_struct
 from aura_core_gen.aura.core.v1 import (
     ActionType,
     Context,
+    DecisionDerivation,
     DecisionOutcome,
     Intent,
     NegotiationIntent,
@@ -101,6 +102,24 @@ def _stamp(decision: Intent, outcome: DecisionOutcome, gate: str) -> Intent:
     return decision
 
 
+def _attach_derivation(decision: Intent, obs_meta: dict[str, Any]) -> Intent:
+    """
+    Record how the guard reached its verdict, from what the guard reported.
+
+    Left unset when no declared gate ran — a decision outside the guard's scope,
+    an unwired Membrane, or one of the Membrane's own checks, none of which are
+    declared in a rule set yet. Attaching an empty digest there would assert a
+    derivation that never happened, which is worse than saying nothing.
+    """
+    sequence = str(obs_meta.get("gate_sequence", ""))
+    digest = str(obs_meta.get("derivation_hash", ""))
+    if sequence or digest:
+        decision.derivation = DecisionDerivation(
+            gate_sequence=sequence, derivation_hash=digest
+        )
+    return decision
+
+
 def _replacing(original: Intent, replacement: Intent) -> Intent:
     """
     Carry forward the fields that name the decision point rather than the decision.
@@ -121,6 +140,7 @@ def _replacing(original: Intent, replacement: Intent) -> Intent:
     replacement.identifier = original.identifier
     replacement.trace = original.trace
     replacement.outcome_gate = original.outcome_gate
+    replacement.derivation = original.derivation
     return replacement
 
 
@@ -361,11 +381,16 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
             },
         )
 
+        obs_meta = obs.metadata.to_dict()
+
+        # Attached to the Intent the guard judged, before any replacement is
+        # built, so `_replacing` carries it across the swap like the rest of the
+        # fields that describe this decision point.
+        _attach_derivation(decision, obs_meta)
+
         if not obs.success:
             # Determine reason for logging/override using structured error code
-            reason = "SAFETY_VIOLATION"
             safe_price = floor_price * 1.05
-            obs_meta = obs.metadata.to_dict()
             reason = str(obs_meta.get("error_code", "SAFETY_VIOLATION"))
             safe_price = float(str(obs_meta.get("safe_price", safe_price)))
 

--- a/core/src/aura_hive/hive/proteins/guard/engine.py
+++ b/core/src/aura_hive/hive/proteins/guard/engine.py
@@ -1,4 +1,6 @@
+import hashlib
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 import structlog
@@ -45,6 +47,60 @@ def _numeric(mapping: dict, key: str, default: float = 0.0) -> float:
         return default
 
 
+# Separates records in the canonical sequence. ASCII unit separator: it cannot
+# occur in a gate id or a premise key, so no escaping rule is needed and the
+# canonical form has one fewer thing to get wrong.
+_RECORD_SEPARATOR = "\x1f"
+
+
+@dataclass(frozen=True)
+class GateRecord:
+    """One gate, as it was evaluated."""
+
+    gate_id: str
+    passed: bool
+    consumes: tuple[str, ...]
+
+    @property
+    def canonical(self) -> str:
+        """`G2_FLOOR_VIOLATION:fail:price,floor_price` — keys, never values."""
+        verdict = "pass" if self.passed else "fail"
+        return f"{self.gate_id}:{verdict}:{','.join(self.consumes)}"
+
+
+@dataclass(frozen=True)
+class Derivation:
+    """
+    The ordered record of how the guard reached its verdict.
+
+    Publishable by construction: it names which premises each gate consulted,
+    never what they were. Recording a value here would give away the floor in a
+    field designed to be handed to the counterparty, undoing the invariant the
+    Membrane spends its whole outbound path enforcing.
+    """
+
+    records: tuple[GateRecord, ...]
+    failed_gate: str | None
+
+    @property
+    def canonical(self) -> str:
+        return _RECORD_SEPARATOR.join(record.canonical for record in self.records)
+
+    @property
+    def digest(self) -> str:
+        """
+        SHA-256 over the canonical sequence, or empty when no gate ran.
+
+        An empty sequence gets an empty digest rather than the hash of the empty
+        string. Hashing nothing would assert a derivation that never happened —
+        a verifier could reproduce the value and learn from it that some gates
+        ran, which is false.
+        """
+        if not self.records:
+            return ""
+        return hashlib.sha256(self.canonical.encode("utf-8")).hexdigest()
+
+
 class SafetyViolation(Exception):
     """
     Raised when a negotiation decision violates safety guardrails.
@@ -56,9 +112,18 @@ class SafetyViolation(Exception):
     branch ("Cannot validate margin: ...") as a margin violation.
     """
 
-    def __init__(self, message: str, code: str = "SAFETY_VIOLATION") -> None:
+    def __init__(
+        self,
+        message: str,
+        code: str = "SAFETY_VIOLATION",
+        derivation: "Derivation | None" = None,
+    ) -> None:
         super().__init__(message)
         self.code = code
+        # The failure path is the raising path, so the record travels on the
+        # exception. Recomputing it in the handler would mean evaluating the
+        # gates twice and hoping both runs agreed.
+        self.derivation = derivation
 
 
 class OutputGuard:
@@ -162,21 +227,52 @@ class OutputGuard:
             "G4_MARGIN_VIOLATION": self._gate_margin_violation,
         }[gate_id]
 
-    def validate_decision(self, decision: dict, context: dict) -> bool:
+    def evaluate(self, decision: dict, context: dict) -> Derivation:
         """
-        Walk the declared gates in order and raise on the first that fails.
+        Walk the declared gates in order, recording each, and stop at the first
+        that fails.
 
         Only accept and counter are judged: those are the actions that put a
         price on the wire. A reject carrying a nonsense price is not a safety
         failure, and refusing it would turn the guard into a validator of
-        decisions nobody acts on.
+        decisions nobody acts on. Such a decision derives nothing, and says so
+        with an empty record rather than a record of gates that did not run.
         """
         if decision.get("action") not in ["accept", "counter"]:
-            return True
+            return Derivation(records=(), failed_gate=None)
 
+        records: list[GateRecord] = []
         for gate in self.ruleset.gates:
-            if not self._predicate(gate.id)(decision, context):
-                raise SafetyViolation(self._MESSAGES[gate.id], code=gate.code)
+            passed = self._predicate(gate.id)(decision, context)
+            records.append(
+                GateRecord(gate_id=gate.id, passed=passed, consumes=gate.consumes)
+            )
+            if not passed:
+                return Derivation(records=tuple(records), failed_gate=gate.id)
+
+        return Derivation(records=tuple(records), failed_gate=None)
+
+    def violation_for(self, derivation: Derivation) -> SafetyViolation:
+        """
+        Build the exception a closed-on-failure derivation implies.
+
+        Separate from `evaluate` so a caller that needs the record on both the
+        passing and failing paths can walk the gates once and decide afterwards.
+        Evaluating twice would be wasteful and, worse, would rest on the two
+        runs agreeing.
+        """
+        assert derivation.failed_gate is not None, "derivation did not fail"
+        gate = {g.id: g for g in self.ruleset.gates}[derivation.failed_gate]
+        return SafetyViolation(
+            self._MESSAGES[gate.id], code=gate.code, derivation=derivation
+        )
+
+    def validate_decision(self, decision: dict, context: dict) -> bool:
+        """Raise on the first gate that fails. `evaluate` does the walking."""
+        derivation = self.evaluate(decision, context)
+
+        if derivation.failed_gate is not None:
+            raise self.violation_for(derivation)
 
         return True
 

--- a/core/src/aura_hive/hive/proteins/guard/skill.py
+++ b/core/src/aura_hive/hive/proteins/guard/skill.py
@@ -6,10 +6,26 @@ from aura_core_gen.aura.core.v1 import Observation
 
 from aura_hive.config.policy import SafetySettings
 
-from .engine import OutputGuard, SafetyViolation
+from .engine import Derivation, OutputGuard, SafetyViolation
 from .schema import SafePriceParams, ValidationParams, VisionValidationParams
 
 logger = logging.getLogger(__name__)
+
+
+def _derivation_fields(derivation: "Derivation | None") -> dict[str, str]:
+    """
+    The record, flattened for Observation metadata.
+
+    Empty strings when nothing was derived rather than omitted keys, so the
+    Membrane reads the same two names on every path and cannot mistake "no gate
+    ran" for "the skill forgot to say".
+    """
+    if derivation is None:
+        return {"gate_sequence": "", "derivation_hash": ""}
+    return {
+        "gate_sequence": derivation.canonical,
+        "derivation_hash": derivation.digest,
+    }
 
 
 class GuardSkill(
@@ -79,7 +95,13 @@ class GuardSkill(
             return Observation(
                 success=False,
                 error=err_msg,
-                metadata=make_struct({"error_code": code, "safe_price": str(safe_p)}),
+                metadata=make_struct(
+                    {
+                        "error_code": code,
+                        "safe_price": str(safe_p),
+                        **_derivation_fields(e.derivation),
+                    }
+                ),
             )
         except Exception as e:
             logger.error(f"Guard skill error: {e}")
@@ -88,8 +110,16 @@ class GuardSkill(
     async def _validate_decision(self, params: dict[str, Any]) -> Observation:
         assert self.provider is not None
         p = ValidationParams(**params)
-        self.provider.validate_decision(p.decision, p.context)
-        return Observation(success=True)
+        # Walked once. The record is wanted on both paths, and re-running the
+        # gates for the failing one would rest on the two runs agreeing.
+        derivation = self.provider.evaluate(p.decision, p.context)
+
+        if derivation.failed_gate is not None:
+            raise self.provider.violation_for(derivation)
+
+        return Observation(
+            success=True, metadata=make_struct(_derivation_fields(derivation))
+        )
 
     async def _get_safe_price(self, params: dict[str, Any]) -> Observation:
         assert self.provider is not None

--- a/core/tests/test_guard_derivation.py
+++ b/core/tests/test_guard_derivation.py
@@ -1,0 +1,193 @@
+"""
+The guard records how it reached its verdict, not just what the verdict was.
+
+`outcome_gate` names the rule that refused a decision. It does not say which
+rules were consulted first, so it cannot be replayed: two deployments could
+report the same failing gate having evaluated entirely different sets on the way
+there. The gate sequence is that record — every gate that ran, in order, with its
+verdict — and `derivation_hash` is a digest over it (docs/DECISION_RECEIPT.md
+§3.4).
+
+The property that makes the record safe to hand to a counterparty is that it
+names premise *keys* and never their values. `G2_FLOOR_VIOLATION:fail:price,
+floor_price` says the floor was consulted; it does not say what the floor is.
+Recording values here would hand over exactly what the DLP gate exists to
+protect, and it would do it in a field designed to be published.
+"""
+
+import pytest
+from aura_hive.hive.proteins.guard.engine import OutputGuard, SafetyViolation
+
+FLOOR = 1000.0
+
+
+class _Safety:
+    min_profit_margin = 0.10
+
+
+def guard(settings: object | None = None) -> OutputGuard:
+    return OutputGuard(safety_settings=settings if settings is not None else _Safety())
+
+
+def decision(price: float, action: str = "counter") -> dict[str, object]:
+    return {"action": action, "price": price}
+
+
+def context(floor: float = FLOOR, cost: float = 500.0) -> dict[str, float]:
+    return {"floor_price": floor, "internal_cost": cost}
+
+
+class TestTheRecordedSequence:
+    def test_a_clean_decision_records_every_gate_as_passed(self) -> None:
+        derivation = guard().evaluate(decision(price=2000.0), context())
+
+        assert derivation.canonical == (
+            "G1_PRICE_POSITIVE:pass:price\x1f"
+            "G2_FLOOR_VIOLATION:pass:price,floor_price\x1f"
+            "G3_SETTINGS_PRESENT:pass:\x1f"
+            "G4_MARGIN_VIOLATION:pass:price,internal_cost"
+        )
+
+    def test_the_sequence_stops_at_the_gate_that_failed(self) -> None:
+        """
+        Short-circuiting is visible in the record rather than hidden by it: the
+        sequence ends at the failure because evaluation did, and a verifier can
+        see that G3 and G4 were never consulted.
+        """
+        derivation = guard().evaluate(decision(price=500.0), context())
+
+        assert derivation.canonical == (
+            "G1_PRICE_POSITIVE:pass:price\x1fG2_FLOOR_VIOLATION:fail:price,floor_price"
+        )
+        assert derivation.failed_gate == "G2_FLOOR_VIOLATION"
+
+    def test_the_gates_are_recorded_in_the_rule_sets_order(self) -> None:
+        derivation = guard().evaluate(decision(price=2000.0), context())
+
+        assert [record.gate_id for record in derivation.records] == [
+            "G1_PRICE_POSITIVE",
+            "G2_FLOOR_VIOLATION",
+            "G3_SETTINGS_PRESENT",
+            "G4_MARGIN_VIOLATION",
+        ]
+
+    def test_a_gate_consuming_nothing_records_an_empty_field(self) -> None:
+        """
+        Not a placeholder character. The draft used an em dash, which is exactly
+        the sort of decorative Unicode a canonical form has to normalise away
+        before hashing — an empty field needs no normalising.
+        """
+        derivation = guard().evaluate(decision(price=2000.0), context())
+        settings_gate = next(
+            r for r in derivation.records if r.gate_id == "G3_SETTINGS_PRESENT"
+        )
+
+        assert settings_gate.consumes == ()
+        assert "G3_SETTINGS_PRESENT:pass:" in derivation.canonical
+
+
+class TestTheRecordNeverCarriesAValue:
+    """
+    The whole record is meant to be publishable. If a value can be read out of
+    it, publishing a receipt undoes the Hidden Knowledge invariant the Membrane
+    spends its outbound path enforcing.
+    """
+
+    @pytest.mark.parametrize("price", [500.0, 2000.0])
+    def test_no_number_from_the_inputs_appears_in_the_sequence(
+        self, price: float
+    ) -> None:
+        derivation = guard().evaluate(
+            decision(price=price), context(floor=FLOOR, cost=777.0)
+        )
+
+        for secret in ("1000", "777", str(price), str(int(price))):
+            assert secret not in derivation.canonical
+
+    def test_two_decisions_differing_only_in_value_derive_identically(self) -> None:
+        """
+        The consequence, stated as a property: the derivation digest is over the
+        steps taken, not the numbers they were taken on. Distinguishing those two
+        prices is the emission digest's job (§3.6), and keeping it out of this
+        field is what stops the digest from being a value oracle.
+        """
+        cheap = guard().evaluate(decision(price=1500.0), context())
+        dear = guard().evaluate(decision(price=9999.0), context())
+
+        assert cheap.digest == dear.digest
+
+
+class TestByteStability:
+    def test_the_same_inputs_derive_byte_identically_across_engines(self) -> None:
+        """
+        Two fresh engines, because a digest that depends on process state cannot
+        be re-derived by anyone else — which is the only thing it is for.
+        """
+        first = guard().evaluate(decision(price=500.0), context())
+        second = guard().evaluate(decision(price=500.0), context())
+
+        assert first.canonical == second.canonical
+        assert first.digest == second.digest
+
+    def test_a_different_outcome_derives_differently(self) -> None:
+        passed = guard().evaluate(decision(price=2000.0), context())
+        failed = guard().evaluate(decision(price=500.0), context())
+
+        assert passed.digest != failed.digest
+
+    def test_the_digest_is_a_full_sha256(self) -> None:
+        digest = guard().evaluate(decision(price=2000.0), context()).digest
+
+        assert len(digest) == 64
+        assert digest == digest.lower()
+        int(digest, 16)
+
+    def test_the_digest_is_over_the_recorded_sequence(self) -> None:
+        """A verifier confirms the two agree before paying to replay the steps."""
+        import hashlib
+
+        derivation = guard().evaluate(decision(price=500.0), context())
+
+        assert (
+            derivation.digest
+            == hashlib.sha256(derivation.canonical.encode("utf-8")).hexdigest()
+        )
+
+
+class TestNothingDerivedIsNotAnEmptyDerivation:
+    def test_an_action_outside_scope_records_no_gates(self) -> None:
+        """
+        No declared gate ran, so there is nothing to replay. Hashing the empty
+        string here would assert a derivation that never happened — the receipt
+        would carry a digest a verifier could reproduce and learn nothing from.
+        """
+        derivation = guard().evaluate(decision(price=-5.0, action="reject"), context())
+
+        assert derivation.records == ()
+        assert derivation.canonical == ""
+        assert derivation.digest == ""
+
+
+class TestValidateDecisionStillBehaves:
+    """The raising contract is unchanged; `evaluate` is the addition beneath it."""
+
+    def test_a_clean_decision_still_returns_true(self) -> None:
+        assert guard().validate_decision(decision(price=2000.0), context())
+
+    def test_a_violation_still_raises_with_its_code(self) -> None:
+        with pytest.raises(SafetyViolation) as caught:
+            guard().validate_decision(decision(price=500.0), context())
+
+        assert caught.value.code == "FLOOR_PRICE_VIOLATION"
+
+    def test_the_violation_carries_the_derivation_that_produced_it(self) -> None:
+        """
+        The failure path needs the record too, and it is the path that raises —
+        so the derivation travels on the exception rather than being recomputed
+        by whoever catches it.
+        """
+        with pytest.raises(SafetyViolation) as caught:
+            guard().validate_decision(decision(price=500.0), context())
+
+        assert caught.value.derivation is not None
+        assert caught.value.derivation.failed_gate == "G2_FLOOR_VIOLATION"

--- a/core/tests/test_membrane_derivation.py
+++ b/core/tests/test_membrane_derivation.py
@@ -1,0 +1,276 @@
+"""
+The derivation travels with the Intent that was actually sent.
+
+`outcome_gate` says which rule refused a decision. It does not say which rules
+were consulted first, so on its own it cannot be replayed: two deployments could
+report the same failing gate having evaluated different sets on the way there.
+The gate sequence closes that, and `derivation_hash` lets a reader confirm the
+sequence has not been edited before paying to replay it
+(docs/DECISION_RECEIPT.md §3.4).
+
+Nothing here is worth having if the record leaks a number, so that is asserted
+against the Intent itself rather than only against the engine that built it.
+"""
+
+import pytest
+from aura_core import SkillRegistry
+from aura_core.struct_utils import make_struct
+from aura_core_gen.aura.core.v1 import (
+    ActionType,
+    Context,
+    DecisionOutcome,
+    Intent,
+    NegotiationIntent,
+    RWAComplianceScore,
+    RWAVaultIntent,
+    TradeIntent,
+    ValidationScore,
+)
+from aura_hive.hive.membrane.main import HiveMembrane
+from aura_hive.hive.proteins.guard import GuardSkill
+from aura_hive.hive.proteins.guard.engine import OutputGuard
+
+FLOOR = 1000.0
+
+
+class _Safety:
+    min_profit_margin = 0.10
+    ui_trigger_price = 1000.0
+    trade_risk_threshold = 0.10
+
+
+def guarded_membrane() -> HiveMembrane:
+    registry = SkillRegistry()
+    guard = GuardSkill()
+    guard.bind(_Safety(), OutputGuard(safety_settings=_Safety()))
+    registry.register(guard.get_name(), guard)
+    return HiveMembrane(registry=registry)
+
+
+def negotiation_context(floor_price: float = FLOOR) -> Context:
+    return Context(
+        metadata=make_struct(
+            {"floor_price": str(floor_price), "internal_cost": "777.0"}
+        )
+    )
+
+
+def counter_intent(price: float) -> Intent:
+    return Intent(
+        action=ActionType.ACTION_TYPE_COUNTER,
+        reasoning="LLM reasoning",
+        negotiation=NegotiationIntent(price=price, message="Here is my offer"),
+    )
+
+
+class TestTheDerivationReachesTheIntent:
+    @pytest.mark.asyncio
+    async def test_an_emitted_decision_carries_the_gates_it_passed(self) -> None:
+        membrane = guarded_membrane()
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=2000.0), negotiation_context()
+        )
+
+        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+        assert decision.derivation.gate_sequence.startswith("G1_PRICE_POSITIVE:pass:")
+        assert "G4_MARGIN_VIOLATION:pass:" in decision.derivation.gate_sequence
+        assert len(decision.derivation.derivation_hash) == 64
+
+    @pytest.mark.asyncio
+    async def test_an_overridden_decision_carries_the_gate_that_stopped_it(
+        self,
+    ) -> None:
+        """
+        The override builds a fresh Intent, so the record has to be carried over
+        deliberately — the same trap `identifier` and `trace` fell into.
+        """
+        membrane = guarded_membrane()
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=500.0), negotiation_context()
+        )
+
+        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
+        assert decision.derivation.gate_sequence == (
+            "G1_PRICE_POSITIVE:pass:price\x1fG2_FLOOR_VIOLATION:fail:price,floor_price"
+        )
+        assert len(decision.derivation.derivation_hash) == 64
+
+    @pytest.mark.asyncio
+    async def test_the_hash_matches_the_sequence_that_travelled(self) -> None:
+        """
+        The pair is redundant on purpose: a reader confirms the two agree with
+        one hash compare and only then pays to replay the steps.
+        """
+        import hashlib
+
+        membrane = guarded_membrane()
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=500.0), negotiation_context()
+        )
+
+        assert (
+            decision.derivation.derivation_hash
+            == hashlib.sha256(
+                decision.derivation.gate_sequence.encode("utf-8")
+            ).hexdigest()
+        )
+
+
+class TestReplay:
+    """
+    The claim the digest makes is that someone else can re-derive it. A digest
+    reproducible only inside one process is worth nothing to the party it is
+    handed to.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("price", [500.0, 2000.0])
+    async def test_the_same_decision_derives_byte_identically_twice(
+        self, price: float
+    ) -> None:
+        """
+        Fresh Membrane, fresh registry, fresh guard on each run — anything that
+        survived between them would be state the verifier does not have.
+        """
+        first = await guarded_membrane().inspect_outbound(
+            counter_intent(price=price), negotiation_context()
+        )
+        second = await guarded_membrane().inspect_outbound(
+            counter_intent(price=price), negotiation_context()
+        )
+
+        assert first.derivation.gate_sequence == second.derivation.gate_sequence
+        assert first.derivation.derivation_hash == second.derivation.derivation_hash
+
+    @pytest.mark.asyncio
+    async def test_a_different_floor_changing_the_verdict_changes_the_digest(
+        self,
+    ) -> None:
+        """
+        The digest tracks the steps, so it moves when the steps do — here
+        because a higher floor makes G2 fail where it had passed.
+        """
+        passing = await guarded_membrane().inspect_outbound(
+            counter_intent(price=1500.0), negotiation_context(floor_price=1000.0)
+        )
+        failing = await guarded_membrane().inspect_outbound(
+            counter_intent(price=1500.0), negotiation_context(floor_price=9000.0)
+        )
+
+        assert passing.derivation.derivation_hash != failing.derivation.derivation_hash
+
+    @pytest.mark.asyncio
+    async def test_a_different_floor_leaving_the_verdict_alone_does_not(self) -> None:
+        """
+        The other half of the same property, and the one that keeps the digest
+        from being a value oracle: two different floors that both pass every
+        gate derive identically, so the digest cannot be probed for the floor.
+        """
+        low = await guarded_membrane().inspect_outbound(
+            counter_intent(price=5000.0), negotiation_context(floor_price=1000.0)
+        )
+        high = await guarded_membrane().inspect_outbound(
+            counter_intent(price=5000.0), negotiation_context(floor_price=2000.0)
+        )
+
+        assert low.derivation.derivation_hash == high.derivation.derivation_hash
+
+
+class TestTheIntentNeverCarriesAValue:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("price", [500.0, 2000.0])
+    async def test_no_hidden_number_appears_in_the_sequence(self, price: float) -> None:
+        """
+        The floor and the internal cost are the two things the Membrane spends
+        its outbound path keeping off the wire. A field meant to be published
+        must not put them back.
+        """
+        membrane = guarded_membrane()
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=price), negotiation_context(floor_price=FLOOR)
+        )
+
+        sequence = decision.derivation.gate_sequence
+        for secret in ("1000", "777", str(price), str(int(price))):
+            assert secret not in sequence
+
+
+class TestNoDeclaredGateRan:
+    """
+    These paths refuse or emit without consulting the rule set, so they have no
+    derivation to show. Attaching an empty-string hash would be a claim that
+    something was derived; leaving the field unset says plainly that nothing was.
+
+    The Membrane's own checks — KYC, trade risk, DLP — are not declared in any
+    rule set yet, so they cannot be recorded as gates without inventing ids
+    nothing versions (docs/DECISION_RECEIPT.md §3.3).
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_kyc_refusal_shows_no_derivation(self) -> None:
+        membrane = guarded_membrane()
+        intent = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            rwa_vault=RWAVaultIntent(
+                wallet_address="0xdead",
+                compliance=RWAComplianceScore(kyc_passed=False),
+            ),
+        )
+
+        decision = await membrane.inspect_outbound(intent, negotiation_context())
+
+        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_REFUSE
+        assert decision.derivation.gate_sequence == ""
+        assert decision.derivation.derivation_hash == ""
+
+    @pytest.mark.asyncio
+    async def test_a_high_risk_trade_refusal_shows_no_derivation(self) -> None:
+        membrane = guarded_membrane()
+        intent = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            trade=TradeIntent(
+                validation_score=ValidationScore(
+                    risk_score=0.9, risk_category="EXTREME"
+                )
+            ),
+        )
+
+        decision = await membrane.inspect_outbound(intent, negotiation_context())
+
+        assert decision.derivation.derivation_hash == ""
+
+    @pytest.mark.asyncio
+    async def test_a_model_reject_shows_no_derivation(self) -> None:
+        """The guard is never consulted: only accept and counter put a price out."""
+        membrane = guarded_membrane()
+
+        decision = await membrane.inspect_outbound(
+            Intent(
+                action=ActionType.ACTION_TYPE_REJECT,
+                negotiation=NegotiationIntent(price=0.0, message="no thanks"),
+            ),
+            negotiation_context(),
+        )
+
+        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+        assert decision.derivation.derivation_hash == ""
+
+    @pytest.mark.asyncio
+    async def test_an_unwired_membrane_shows_no_derivation(self) -> None:
+        """
+        No registry means no guard ran. Claiming a derivation here would be the
+        worst version of the lie: a receipt asserting gates on a deployment that
+        has none wired.
+        """
+        membrane = HiveMembrane(registry=None)
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=2000.0), negotiation_context()
+        )
+
+        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+        assert decision.derivation.derivation_hash == ""

--- a/core/tests/test_membrane_derivation.py
+++ b/core/tests/test_membrane_derivation.py
@@ -21,6 +21,7 @@ from aura_core_gen.aura.core.v1 import (
     DecisionOutcome,
     Intent,
     NegotiationIntent,
+    Observation,
     RWAComplianceScore,
     RWAVaultIntent,
     TradeIntent,
@@ -197,6 +198,75 @@ class TestTheIntentNeverCarriesAValue:
         sequence = decision.derivation.gate_sequence
         for secret in ("1000", "777", str(price), str(int(price))):
             assert secret not in sequence
+
+
+class TestAGuardThatReportsNothingUsable:
+    """
+    The Membrane reads the record out of whatever the guard skill reported, and
+    a skill is free to report an Observation it did not fill in.
+
+    Neither case below is reachable from `GuardSkill` today, which always
+    returns both keys as strings. They are guarded because this PR moved
+    `metadata.to_dict()` onto the passing path, where it had never run before —
+    the failure path was the only caller until now — and because attaching a
+    derivation built from junk is the exact thing the empty-record rule exists
+    to prevent.
+    """
+
+    class _SilentGuard:
+        """A guard protein that answers without filling in its metadata."""
+
+        def __init__(self, observation: Observation) -> None:
+            self._observation = observation
+
+        def get_name(self) -> str:
+            return "guard"
+
+        async def execute(self, intent: str, params: dict) -> Observation:
+            return self._observation
+
+    def membrane_reporting(self, observation: Observation) -> HiveMembrane:
+        registry = SkillRegistry()
+        registry.register("guard", self._SilentGuard(observation))
+        return HiveMembrane(registry=registry)
+
+    @pytest.mark.asyncio
+    async def test_an_observation_without_metadata_does_not_take_the_guard_down(
+        self,
+    ) -> None:
+        """
+        A crash here would lose the negotiation, and it would do so inside the
+        one component whose job is to never let a bad decision out.
+        """
+        membrane = self.membrane_reporting(Observation(success=True, metadata=None))
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=2000.0), negotiation_context()
+        )
+
+        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+        assert decision.derivation.derivation_hash == ""
+
+    @pytest.mark.asyncio
+    async def test_a_null_valued_record_is_not_attached_as_the_word_none(self) -> None:
+        """
+        `str(None)` is "None", which is truthy — so the naive read would attach a
+        DecisionDerivation whose sequence is the literal text None and whose
+        hash claims a derivation that never ran.
+        """
+        membrane = self.membrane_reporting(
+            Observation(
+                success=True,
+                metadata=make_struct({"gate_sequence": None, "derivation_hash": None}),
+            )
+        )
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=2000.0), negotiation_context()
+        )
+
+        assert decision.derivation.gate_sequence == ""
+        assert decision.derivation.derivation_hash == ""
 
 
 class TestNoDeclaredGateRan:

--- a/docs/DECISION_RECEIPT.md
+++ b/docs/DECISION_RECEIPT.md
@@ -162,23 +162,48 @@ gate lists (`KYC_PASSED`, `RISK_THRESHOLD`, `HILL_CEILING`, `WALLET_SANCTIFIED`)
 
 ### 3.4 `derivation-hash` and `gate-sequence`
 
-Our derivation *is* the ordered gate evaluation. Each record:
+**Implemented**, as `Intent.derivation` (`DecisionDerivation`). Our derivation *is* the ordered gate
+evaluation. Each record:
 
 ```
-<gate-id>:<verdict>:<premise-keys-consumed>
+<gate-id>:<pass|fail>:<premise-keys-consumed>
 ```
 
-e.g. `G4_FLOOR_VIOLATION:pass:bid,floor_price` — note it names the *keys*, never the values.
+Records are joined by ASCII unit separator `0x1F` — it cannot occur in a gate id or a premise key, so
+the canonical form needs no escaping rule. A real sequence, for a price below floor:
 
-`derivation-hash = SHA256(canon(gate-sequence))`. The two fields are redundant by design (VISION
-§5.1.6bis): a verifier does one constant-time hash compare for structural integrity, and only then
-pays for replay. This is the part of the spec that fits us best — commit #250 already made the
-structural guard deterministic, so replay is genuinely reproducible today.
+```
+G1_PRICE_POSITIVE:pass:price␟G2_FLOOR_VIOLATION:fail:price,floor_price
+```
 
-**Gates short-circuit, and only the first failing gate is recorded.** Not a convenience — VISION
-§4.3.5's reasoning applies to us directly: enumerating every gate that *would* have fired gives an
-adversary an oracle over our policy configuration. They probe until they map the boundary, and the
-boundary is `floor_price`.
+`derivation-hash = SHA256(gate-sequence)`, lowercase hex64. The two fields are redundant by design
+(VISION §5.1.6bis): a reader does one hash compare for structural integrity, and only then pays for
+replay.
+
+**The record names premise keys, never values.** This is the property that makes it publishable, and
+it is asserted directly — `test_no_hidden_number_appears_in_the_sequence` checks that neither the
+floor, the internal cost, nor the price appears anywhere in the sequence that reaches the Intent.
+Two consequences worth stating as properties, both tested:
+
+- Two decisions differing only in price derive **identically**. Distinguishing them is the emission
+  digest's job (§3.6). Keeping values out of this field is what stops the digest being a value
+  oracle — you cannot probe it for the floor.
+- The digest moves when the *steps* move: raising the floor so that `G2` fails where it passed
+  changes it, but changing the floor while every gate still passes does not.
+
+**Gates short-circuit, and the sequence ends where evaluation did.** A reader can see that the gates
+after the failure were never consulted. This pairs with §4.3.5's reasoning behind `outcome_gate`
+recording only the first failure: enumerating every gate that *would* have fired gives an adversary
+an oracle over the policy configuration, and the boundary they would map is `floor_price`.
+
+**Nothing derived is not an empty derivation.** When no declared gate ran — a decision outside the
+guard's scope, an unwired Membrane, or one of the Membrane's own checks — the field is left unset
+rather than carrying the hash of an empty string. Hashing nothing would assert a derivation that
+never happened, and a verifier could reproduce that digest and conclude, falsely, that gates ran.
+
+Note this covers the *guard's declared gates only*. KYC, trade-risk and DLP are Membrane-level checks
+that no rule set declares, so they cannot be recorded as gates without inventing ids nothing versions
+(§3.3). Those paths refuse with an `outcome_gate` and no derivation, which is the honest report.
 
 ### 3.5 `policy-stamp`
 
@@ -287,7 +312,11 @@ committed beforehand. What they do not learn: the floor, the margin, the cost.
    carries the gate's code, replacing the substring match on the exception message. Covered by
    `core/tests/test_guard_{ruleset,gates}.py`. Caveat in §3.3: predicate bodies are still outside
    the digest.
-3. Emit `gate-sequence` + `derivation-hash`; add a replay test asserting byte-stability across runs.
+3. ~~Emit `gate-sequence` + `derivation-hash`; add a replay test asserting byte-stability across
+   runs.~~ **DONE.** `DecisionDerivation` on `Intent`; `OutputGuard.evaluate()` walks the gates once
+   and returns the record, which travels on `SafetyViolation` for the failing path. Replay tests
+   build a fresh Membrane, registry and guard per run, since anything surviving between them is
+   state a verifier does not have. Covered by `core/tests/test_{guard,membrane}_derivation.py`.
 4. Add hashes, salt, split policy stamp.
 5. Sign with the identity key; wire `canonical-prefix` into logs and frontend.
 6. Typed `DecisionReceipt` proto message; bee-keeper verifies receipts in CI audit.

--- a/proto/aura/core/v1/metabolism.proto
+++ b/proto/aura/core/v1/metabolism.proto
@@ -197,6 +197,35 @@ enum DecisionOutcome {
   DECISION_OUTCOME_REFUSE = 3;     // a gate fired; the action was rejected
 }
 
+// The ordered record of how the guard reached its verdict, and a digest over it.
+//
+// `outcome_gate` names the rule that refused a decision but not the rules
+// consulted before it, so on its own it cannot be replayed: two deployments
+// could report the same failing gate having evaluated different sets on the way
+// there. This is that record.
+//
+// Grouped in a message rather than added as two more scalars on Intent so the
+// remaining receipt fields (premise hash, policy stamp, signature) have
+// somewhere to land without spreading across Intent's number space. See
+// docs/DECISION_RECEIPT.md §3.4.
+message DecisionDerivation {
+  // Gate records in evaluation order, separated by ASCII unit separator (0x1F).
+  // Each record is `<gate-id>:<pass|fail>:<comma-separated premise keys>`.
+  //
+  // Premise KEYS, never their values. This field is meant to be publishable,
+  // and recording a value would hand the counterparty the floor price in the
+  // one place designed to be read by them — undoing the invariant the Membrane
+  // spends its entire outbound path enforcing.
+  string gate_sequence = 1;
+
+  // SHA-256 over gate_sequence, lowercase hex. Empty when no gate ran: hashing
+  // an empty sequence would assert a derivation that never happened.
+  //
+  // Redundant with gate_sequence by design. A reader confirms the two agree
+  // with one constant-time compare, and only then pays to replay the steps.
+  string derivation_hash = 2;
+}
+
 message Intent {
   string identifier = 1;  // Schema.org compliant
   ActionType action = 2;
@@ -217,6 +246,9 @@ message Intent {
   // read back which invariants answered, and the shape of the hidden floor
   // falls out. This constrains only what is recorded — every gate still runs.
   string outcome_gate = 8;
+
+  // How the Membrane reached that verdict. Absent when no declared gate ran.
+  DecisionDerivation derivation = 9;
 
   // Strictly typed action params
   oneof params {


### PR DESCRIPTION
Step 3 of `docs/DECISION_RECEIPT.md` §6. Follows #255 and #258.

## Why

`Intent.outcome_gate` names the rule that refused a decision. It does not name the rules consulted before it, so on its own it cannot be replayed — two deployments could report the same failing gate having evaluated entirely different sets on the way there.

## What

`DecisionDerivation` on `Intent`: every gate that ran, in order, with its verdict, plus a SHA-256 over the sequence.

```
G1_PRICE_POSITIVE:pass:price␟G2_FLOOR_VIOLATION:fail:price,floor_price
```

Records are joined by ASCII unit separator (`0x1F`), which cannot occur in a gate id or a premise key, so the canonical form needs no escaping rule. The hash and the sequence are redundant on purpose (VISION §5.1.6bis): a reader confirms they agree with one compare and only then pays to replay.

## The property that matters: keys, never values

This field is meant to be publishable, so a value read out of it would undo the Hidden Knowledge invariant the Membrane spends its whole outbound path enforcing — in the one place designed to be read by the counterparty.

Asserted against the `Intent` rather than only the engine that built it: neither the floor, the internal cost, nor the price appears anywhere in the sequence. Two consequences fall out, both tested as properties:

- **Two decisions differing only in price derive identically.** The digest cannot be probed for the floor. Distinguishing them is the emission digest's job (§3.6).
- **The digest moves when the steps move.** Raising the floor so `G2` fails where it passed changes it; changing the floor while every gate still passes does not.

## Nothing derived is not an empty derivation

When no declared gate ran — an action outside the guard's scope, an unwired Membrane, or one of the Membrane's own checks — the field is left unset rather than carrying `sha256("")`.

Hashing nothing would assert a derivation that never happened: a verifier could reproduce that digest and conclude, falsely, that gates ran. The worst version is an unwired deployment claiming gates it has none of, which has its own test.

## Scope

The guard's **declared** gates only. KYC, trade-risk and DLP are Membrane-level checks that no rule set declares, so recording them as gates would mean inventing ids nothing versions (§3.3). Those paths refuse with an `outcome_gate` and no derivation — the honest report, and tested as such.

## Notes for review

- **The gates are walked once.** `evaluate()` returns the record; `violation_for()` builds the exception from it. The first cut had the skill call `evaluate` and then `validate_decision`, which evaluated twice and rested on the two runs agreeing — worth flagging since that is exactly the kind of thing a determinism claim should not be built on.
- **The record travels on `SafetyViolation`**, because the failing path is the raising path. Recomputing it in the handler would be the double-evaluation problem again.
- **Grouped in a message**, not two more scalars on `Intent`. `outcome`/`outcome_gate` from #255 are already at 7 and 8; the remaining receipt fields (premise hash, policy stamp, signature) now have somewhere to land instead of spreading across `Intent`'s number space, and step 6 folds the message into `DecisionReceipt` naturally.
- **`_replacing()` carries it across the override**, the same trap `identifier` and `trace` fell into on #255.

## Testing

Two red-green cycles, engine then Membrane. Replay tests build a fresh Membrane, registry and guard per run — anything surviving between them is state a verifier does not have.

```
core/tests/test_guard_derivation.py     15 passed  (new)
core/tests/test_membrane_derivation.py  13 passed  (new)
core/tests/                            326 passed  (was 298)
api-gateway / telegram-bot / bee-keeper   1 / 6 / 7 passed
ruff check + format                       clean
mypy core/src                             85 files, no issues
buf lint                                  clean
tools/check_fractal_completeness.py       OK
```

Proto field 9 is new and additive; the `params` oneof is untouched at 10–15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)