### PR TITLE
feat(membrane): gather what the Membrane can attest into one receipt

### DIFF
--- a/core/src/aura_hive/hive/membrane/main.py
+++ b/core/src/aura_hive/hive/membrane/main.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any, cast
 
 import betterproto
@@ -16,6 +17,8 @@ from aura_core_gen.aura.core.v1 import (
 from prometheus_client import REGISTRY, Counter
 
 from aura_hive.config import get_settings
+
+from .receipt import mint
 
 logger = structlog.get_logger(__name__)
 
@@ -82,46 +85,72 @@ _OVERRIDE = cast(DecisionOutcome, DecisionOutcome.DECISION_OUTCOME_OVERRIDE)
 _REFUSE = cast(DecisionOutcome, DecisionOutcome.DECISION_OUTCOME_REFUSE)
 
 
-def _stamp(decision: Intent, outcome: DecisionOutcome, gate: str) -> Intent:
+@dataclass
+class _Verdict:
     """
-    Record what the Membrane did, on the Intent that will actually be sent.
+    The Membrane's finding, accumulated as the outbound path proceeds.
+
+    Kept here rather than written onto the Intent as it goes, because the Intent
+    on the override path is replaced part-way and a verdict half-written onto a
+    discarded object is how `outcome_gate` nearly lost its first gate.
 
     First gate wins. A decision that trips DLP and then the floor check records
     DLP_BLOCK, the earlier one: reporting every gate that fired would hand an
     adversary an oracle over the policy configuration — probe with crafted
     offers, read back which invariants answered, and the shape of the hidden
-    floor falls out.
-
-    This constrains only what is *recorded*. Every gate still executes;
-    short-circuiting the floor check to keep the label tidy would trade a
-    guarantee for a string.
+    floor falls out. This constrains only what is recorded; every gate still
+    executes.
     """
-    decision.outcome = outcome
-    if not decision.outcome_gate:
-        decision.outcome_gate = gate
-    return decision
+
+    outcome: DecisionOutcome = _EMIT
+    gate: str = ""
+    ruleset_version: str = ""
+    derivation: DecisionDerivation | None = None
+
+    def record(self, outcome: DecisionOutcome, gate: str) -> None:
+        self.outcome = outcome
+        if not self.gate:
+            self.gate = gate
+
+    def read_guard_report(self, obs_meta: dict[str, Any]) -> None:
+        """
+        Take the rule set and the derivation from what the guard reported.
+
+        `or ""` rather than a default, because `str(None)` is "None" — truthy,
+        and it would record a sequence of that literal text and a hash claiming
+        a derivation that never ran. A Struct round-trips a null value back as
+        None, so a key being present is not the same as it carrying one.
+        """
+        self.ruleset_version = str(obs_meta.get("ruleset_version") or "")
+        sequence = str(obs_meta.get("gate_sequence") or "")
+        digest = str(obs_meta.get("derivation_hash") or "")
+        # Left unset when no declared gate ran — a decision outside the guard's
+        # scope, an unwired Membrane, or one of the Membrane's own checks, none
+        # of which are declared in a rule set. Recording an empty digest there
+        # would assert a derivation that never happened.
+        if sequence or digest:
+            self.derivation = DecisionDerivation(
+                gate_sequence=sequence, derivation_hash=digest
+            )
 
 
-def _attach_derivation(decision: Intent, obs_meta: dict[str, Any]) -> Intent:
+def _finish(claim: Intent, emission: Intent, verdict: _Verdict) -> Intent:
     """
-    Record how the guard reached its verdict, from what the guard reported.
+    Attach the receipt and hand back the Intent that will actually be sent.
 
-    Left unset when no declared gate ran — a decision outside the guard's scope,
-    an unwired Membrane, or one of the Membrane's own checks, none of which are
-    declared in a rule set yet. Attaching an empty digest there would assert a
-    derivation that never happened, which is worse than saying nothing.
+    `claim` is what the Transformer proposed and `emission` is what is going
+    out; they are the same object when the Membrane changed nothing, and the two
+    hashes agreeing is then a fact a reader can check rather than an assumption.
     """
-    # `or ""` rather than a default, because `str(None)` is "None" — truthy, and
-    # it would attach a record whose sequence is that literal text and whose
-    # hash claims a derivation that never ran. A Struct round-trips a null value
-    # back as None, so a key being present is not the same as it carrying one.
-    sequence = str(obs_meta.get("gate_sequence") or "")
-    digest = str(obs_meta.get("derivation_hash") or "")
-    if sequence or digest:
-        decision.derivation = DecisionDerivation(
-            gate_sequence=sequence, derivation_hash=digest
-        )
-    return decision
+    emission.receipt = mint(
+        claim=claim,
+        emission=emission,
+        outcome=verdict.outcome,
+        outcome_gate=verdict.gate,
+        ruleset_version=verdict.ruleset_version,
+        derivation=verdict.derivation,
+    )
+    return emission
 
 
 def _replacing(original: Intent, replacement: Intent) -> Intent:
@@ -143,22 +172,7 @@ def _replacing(original: Intent, replacement: Intent) -> Intent:
     """
     replacement.identifier = original.identifier
     replacement.trace = original.trace
-    replacement.outcome_gate = original.outcome_gate
-    replacement.derivation = original.derivation
     return replacement
-
-
-def _settle(decision: Intent) -> Intent:
-    """
-    Nothing further fired, so the Membrane emitted what it was given.
-
-    EMIT is claimed only when no earlier gate has already stamped this Intent —
-    a message sanitised by DLP is still an override even though the price that
-    follows it passes the guard untouched.
-    """
-    if not decision.outcome_gate:
-        decision.outcome = _EMIT
-    return decision
 
 
 def _action_label(action: Any) -> str:
@@ -269,6 +283,11 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
         ctx_meta = context.metadata.to_dict()
         floor_price = float(str(ctx_meta.get("floor_price", 0.0)))
 
+        # Accumulated as the path proceeds and minted once, at whichever return
+        # is taken. `decision` is the claim throughout: the only edit before the
+        # receipt is built is DLP rewriting prose, which the claim excludes.
+        verdict = _Verdict()
+
         params_name, params_value = betterproto.which_one_of(decision, "params")
 
         # RWA vault guard: backstop for KYC failures that slipped through
@@ -281,7 +300,9 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                     violation_code=rwa_intent.compliance.violation_code,
                     wallet_address=rwa_intent.wallet_address,
                 )
-                return _stamp(
+                verdict.record(_REFUSE, "KYC_FAILURE")
+                return _finish(
+                    decision,
                     _replacing(
                         decision,
                         Intent(
@@ -291,10 +312,9 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                             rwa_vault=rwa_intent,
                         ),
                     ),
-                    _REFUSE,
-                    "KYC_FAILURE",
+                    verdict,
                 )
-            return _settle(decision)
+            return _finish(decision, decision, verdict)
 
         # Trade intent guard: backstop for high-risk trades that slipped through
         if params_name == "trade" and params_value is not None:
@@ -308,7 +328,9 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                     risk_score=risk_score,
                     risk_category=trade_intent.validation_score.risk_category,
                 )
-                return _stamp(
+                verdict.record(_REFUSE, "HIGH_RISK_TRADE")
+                return _finish(
+                    decision,
                     _replacing(
                         decision,
                         Intent(
@@ -318,10 +340,9 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                             trade=trade_intent,
                         ),
                     ),
-                    _REFUSE,
-                    "HIGH_RISK_TRADE",
+                    verdict,
                 )
-            return _settle(decision)
+            return _finish(decision, decision, verdict)
 
         neg_intent = params_value if params_name == "negotiation" else None
 
@@ -343,7 +364,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                     )
 
             return self._override_with_safe_offer(
-                decision, safe_price, "FAILURE_RECOVERY"
+                decision, safe_price, "FAILURE_RECOVERY", verdict
             )
 
         # 2. DLP Check
@@ -353,17 +374,17 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                 neg_intent.message = "I cannot disclose internal pricing details."
             decision.reasoning += " [MEMBRANE: DLP block]"
             _record_intervention("outbound", "DLP_BLOCK")
-            _stamp(decision, _OVERRIDE, "DLP_BLOCK")
+            verdict.record(_OVERRIDE, "DLP_BLOCK")
 
         if decision.action not in [
             ActionType.ACTION_TYPE_ACCEPT,
             ActionType.ACTION_TYPE_COUNTER,
         ]:
-            return _settle(decision)
+            return _finish(decision, decision, verdict)
 
         # 3. Call Guard Protein for validation
         if not self.registry:
-            return _settle(decision)
+            return _finish(decision, decision, verdict)
 
         internal_cost = float(str(ctx_meta.get("internal_cost", floor_price)))
         guard_context = {"floor_price": floor_price, "internal_cost": internal_cost}
@@ -396,7 +417,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
         # Attached to the Intent the guard judged, before any replacement is
         # built, so `_replacing` carries it across the swap like the rest of the
         # fields that describe this decision point.
-        _attach_derivation(decision, obs_meta)
+        verdict.read_guard_report(obs_meta)
 
         if not obs.success:
             # Determine reason for logging/override using structured error code
@@ -404,12 +425,12 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
             reason = str(obs_meta.get("error_code", "SAFETY_VIOLATION"))
             safe_price = float(str(obs_meta.get("safe_price", safe_price)))
 
-            return self._override_with_safe_offer(decision, safe_price, reason)
+            return self._override_with_safe_offer(decision, safe_price, reason, verdict)
 
-        return _settle(decision)
+        return _finish(decision, decision, verdict)
 
     def _override_with_safe_offer(
-        self, original: Intent, safe_price: float, reason: str
+        self, original: Intent, safe_price: float, reason: str, verdict: _Verdict
     ) -> Intent:
         _record_intervention("outbound", reason, safe_price=round(safe_price, 2))
         rounded_price = round(safe_price, 2)
@@ -435,4 +456,5 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                 message=f"I've reached my final limit for this item. My best offer is ${rounded_price:.2f}.",
             ),
         )
-        return _stamp(_replacing(original, replacement), _OVERRIDE, reason)
+        verdict.record(_OVERRIDE, reason)
+        return _finish(original, _replacing(original, replacement), verdict)

--- a/core/src/aura_hive/hive/membrane/main.py
+++ b/core/src/aura_hive/hive/membrane/main.py
@@ -162,9 +162,9 @@ def _replacing(original: Intent, replacement: Intent) -> Intent:
     Intent starts blank. It still stands for the same point in the metabolic
     cycle, so identity and trace belong to it as much as to what it replaced.
 
-    `outcome_gate` travels for a sharper reason: without it a decision that
-    tripped DLP and was then overridden by the floor check would report the
-    floor as the first gate, losing the earlier one.
+    The verdict does not travel here any more: it is accumulated in a `_Verdict`
+    and minted onto the emission, which is what stopped a decision that tripped
+    DLP and was then overridden from reporting the floor as its first gate.
 
     Nothing reads `Intent.trace` today — the trace that reaches the Observation
     comes from `Context.trace` by way of the Connector. Carrying it is cheap and
@@ -173,6 +173,30 @@ def _replacing(original: Intent, replacement: Intent) -> Intent:
     replacement.identifier = original.identifier
     replacement.trace = original.trace
     return replacement
+
+
+def _context_number(ctx_meta: dict[str, Any], key: str, default: float) -> float:
+    """
+    Read a number out of Context.metadata that may not be one.
+
+    A Struct round-trips a JSON null back as None, and the previous read was
+    `float(str(ctx_meta.get(key, default)))` — so a null became `float("None")`
+    and a ValueError. Nothing catches it: `MetabolicLoop.execute` wraps neither
+    membrane call, so the exception leaves the cycle and the negotiation is lost.
+
+    That is the wrong failure for the component whose job is to be the thing
+    that does not let a bad decision out. Refusing safely is its business;
+    crashing on its own input is not. An unusable value reads as absent, which
+    is what the default already meant.
+    """
+    value = ctx_meta.get(key, default)
+    if value is None:
+        return default
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        logger.warning("membrane_unusable_context_number", key=key, value=repr(value))
+        return default
 
 
 def _action_label(action: Any) -> str:
@@ -281,7 +305,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
 
     async def inspect_outbound(self, decision: Intent, context: Context) -> Intent:
         ctx_meta = context.metadata.to_dict()
-        floor_price = float(str(ctx_meta.get("floor_price", 0.0)))
+        floor_price = _context_number(ctx_meta, "floor_price", 0.0)
 
         # Accumulated as the path proceeds and minted once, at whichever return
         # is taken. `decision` is the claim throughout: the only edit before the
@@ -386,7 +410,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
         if not self.registry:
             return _finish(decision, decision, verdict)
 
-        internal_cost = float(str(ctx_meta.get("internal_cost", floor_price)))
+        internal_cost = _context_number(ctx_meta, "internal_cost", floor_price)
         guard_context = {"floor_price": floor_price, "internal_cost": internal_cost}
 
         price = neg_intent.price if neg_intent else 0.0

--- a/core/src/aura_hive/hive/membrane/receipt.py
+++ b/core/src/aura_hive/hive/membrane/receipt.py
@@ -22,6 +22,7 @@ from typing import Any
 import betterproto
 from aura_core_gen.aura.core.v1 import (
     ActionType,
+    AssetIntent,
     DecisionDerivation,
     DecisionOutcome,
     DecisionReceipt,
@@ -136,8 +137,24 @@ def canonical_claim(intent: Intent) -> str:
             f"wallet={vault.wallet_address}"
         )
 
-    # Anything else — including the bare ERROR Intent the FAILURE_RECOVERY path
-    # arrives with — has no decidable content beyond its shape.
+    if params_name == "asset" and params_value is not None:
+        asset: AssetIntent = params_value
+        # The domain is part of the claim: the same identifier in two domains is
+        # not the same asset.
+        return (
+            f"{shape};"
+            f"asset={asset.asset_identifier};"
+            f"domain={asset.asset_domain};"
+            f"asset_action={_action_name(asset.action_type)}"
+        )
+
+    # Anything else has no decidable content beyond its shape, and the fallback
+    # is a stated boundary rather than an oversight. It covers the bare ERROR
+    # Intent the FAILURE_RECOVERY path arrives with, and `audit` / `ui`, which
+    # are internal control intents whose content is mostly prose — narratives
+    # and rendering instructions. Their receipts identify a shape, not a
+    # decision. Any params type that grows outward-facing content needs a branch
+    # above, or it inherits the collision this fallback carries.
     return shape
 
 

--- a/core/src/aura_hive/hive/membrane/receipt.py
+++ b/core/src/aura_hive/hive/membrane/receipt.py
@@ -27,6 +27,8 @@ from aura_core_gen.aura.core.v1 import (
     DecisionReceipt,
     Intent,
     NegotiationIntent,
+    RWAVaultIntent,
+    TradeIntent,
 )
 
 # The signed format will take its own name rather than flipping a flag on this
@@ -98,9 +100,45 @@ def canonical_claim(intent: Intent) -> str:
             f"price={negotiation.price:.2f}"
         )
 
-    # Trade and vault decisions have no price to canonicalise here. The shape
-    # still has to be recorded, or two unrelated decisions would hash alike.
-    return f"action={action};params={params_name or 'none'}"
+    shape = f"action={action};params={params_name or 'none'}"
+
+    # Recording only the shape was the first cut and the wrong half of the job.
+    # `action=approve;params=trade` is the same string for every trade there has
+    # ever been, so a ten-dollar trade and a nine-million-dollar one produced
+    # one digest — a "digest of the decision the Transformer proposed" that does
+    # not identify a decision.
+    #
+    # Harmless while nothing signs a receipt: anyone able to move one onto
+    # another Intent can equally mint a fresh one, since `mint` holds no secret.
+    # It stops being harmless the moment a signature makes a receipt worth
+    # lifting, which is why the collision goes now rather than being inherited
+    # by the format that will have something to protect.
+    if params_name == "trade" and params_value is not None:
+        trade: TradeIntent = params_value
+        return (
+            f"{shape};"
+            f"trade={trade.trade_id};"
+            f"asset={trade.asset_identifier};"
+            f"price={trade.proposed_price:.2f};"
+            f"currency={trade.currency_code}"
+        )
+
+    if params_name == "rwa_vault" and params_value is not None:
+        vault: RWAVaultIntent = params_value
+        # The wallet is part of the claim: same collateral against a different
+        # beneficiary is a different decision, not a restatement of one.
+        return (
+            f"{shape};"
+            f"vault={vault.vault_id};"
+            f"asset={vault.asset_identifier};"
+            f"appraised={vault.appraised_value_usd:.2f};"
+            f"ltv={vault.ltv_ratio:.4f};"
+            f"wallet={vault.wallet_address}"
+        )
+
+    # Anything else — including the bare ERROR Intent the FAILURE_RECOVERY path
+    # arrives with — has no decidable content beyond its shape.
+    return shape
 
 
 def claim_digest(intent: Intent) -> str:
@@ -194,6 +232,12 @@ def verify(receipt: DecisionReceipt) -> VerificationResult:
         expected = hashlib.sha256(derivation.gate_sequence.encode("utf-8")).hexdigest()
         if derivation.derivation_hash != expected:
             failures.append("derivation hash does not match the recorded gate sequence")
+
+    if receipt.outcome == DecisionOutcome.DECISION_OUTCOME_UNSPECIFIED:
+        # Zero is protobuf's default, so an outcome nobody set is
+        # indistinguishable from a field never written. A receipt whose central
+        # claim is absent must not pass for one that merely had nothing go wrong.
+        failures.append("receipt outcome is unspecified")
 
     changed = receipt.claim_hash != receipt.emission_hash
 

--- a/core/src/aura_hive/hive/membrane/receipt.py
+++ b/core/src/aura_hive/hive/membrane/receipt.py
@@ -1,0 +1,220 @@
+"""
+Mints and checks what the Membrane can attest about a decision.
+
+This is not a receipt in the sense VISION means. §5.1.7 holds that a receipt
+without a valid verifier signature is not a receipt regardless of any other
+field, and neither the signature (§3.7) nor the premise hash (§3.1) is built —
+both wait on decisions this code cannot make for itself: who holds the salt, and
+what key signs.
+
+So the format calls itself UNSIGNED and `verify` reports what it could not
+check. A verifier that answers "valid" while silently skipping the integrity
+check is worse than no verifier: it teaches its consumer to rely on a guarantee
+nobody made.
+
+See docs/DECISION_RECEIPT.md §3 for the field-by-field design.
+"""
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+import betterproto
+from aura_core_gen.aura.core.v1 import (
+    ActionType,
+    DecisionDerivation,
+    DecisionOutcome,
+    DecisionReceipt,
+    Intent,
+    NegotiationIntent,
+)
+
+# The signed format will take its own name rather than flipping a flag on this
+# one, so that a consumer written against it cannot be satisfied by a downgrade.
+RECEIPT_VERSION = "AURA-RECEIPT-V0-UNSIGNED"
+
+# Width of the human-legible handle, in hex characters. Enough to be distinctive
+# in a log line, and not a commitment — nothing is bound until something signs.
+_PREFIX_CHARS = 16
+
+# Gates that alter prose and nothing else, so an override under one of them
+# leaves claim and emission hashing alike. Naming them is what lets `verify`
+# distinguish that legitimate case from a receipt claiming a substitution that
+# did not happen.
+_PROSE_ONLY_GATES = frozenset({"DLP_BLOCK"})
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """
+    What a reader learned, including what they did not.
+
+    `attested` is deliberately separate from `ok`: everything checkable can pass
+    while the receipt remains unattested, and collapsing the two would let
+    "nothing was wrong" read as "someone vouched for this".
+    """
+
+    ok: bool
+    failures: tuple[str, ...] = ()
+    unverifiable: tuple[str, ...] = ()
+    attested: bool = False
+
+
+def _action_name(action: Any) -> str:
+    """
+    `counter`, not `ACTION_TYPE_COUNTER` or `2`.
+
+    The number would be stable too, but the canonical form is meant to be read
+    by a human reconciling a receipt against a conversation, and a bare 2 makes
+    that a lookup.
+    """
+    try:
+        name = ActionType(int(action)).name or ""
+    except (ValueError, TypeError):
+        return f"action_{action}"
+    return name.removeprefix("ACTION_TYPE_").lower()
+
+
+def canonical_claim(intent: Intent) -> str:
+    """
+    The decidable content of a decision, as a stable string.
+
+    Prose is excluded — `reasoning`, `message` and `thought` are the model's free
+    text. They are not what the decision decides, and hashing them would make the
+    digest irreproducible for anyone who did not receive the byte-exact string.
+
+    The price is rendered to fixed precision because a float is not stable enough
+    to hash: 105.0, 105.00 and 105.000000001 must be one claim, and arithmetic
+    hands you the last of those.
+    """
+    params_name, params_value = betterproto.which_one_of(intent, "params")
+    action = _action_name(intent.action)
+
+    if params_name == "negotiation" and params_value is not None:
+        negotiation: NegotiationIntent = params_value
+        return (
+            f"action={action};"
+            f"item={negotiation.item_identifier};"
+            f"price={negotiation.price:.2f}"
+        )
+
+    # Trade and vault decisions have no price to canonicalise here. The shape
+    # still has to be recorded, or two unrelated decisions would hash alike.
+    return f"action={action};params={params_name or 'none'}"
+
+
+def claim_digest(intent: Intent) -> str:
+    """SHA-256 over the canonical claim, lowercase hex."""
+    return hashlib.sha256(canonical_claim(intent).encode("utf-8")).hexdigest()
+
+
+def _content_fields(receipt: DecisionReceipt) -> str:
+    """
+    The fields the prefix commits to, concatenated in fixed order.
+
+    Order is part of the canonical form: reordering would produce a different
+    prefix and fail verification, which is the intended behaviour rather than an
+    inconvenience.
+    """
+    derivation = receipt.derivation or DecisionDerivation()
+    return "\n".join(
+        [
+            receipt.version,
+            receipt.claim_hash,
+            receipt.ruleset_version,
+            derivation.derivation_hash,
+            receipt.emission_hash,
+            str(int(receipt.outcome)),
+            receipt.outcome_gate,
+        ]
+    )
+
+
+def _prefix(receipt: DecisionReceipt) -> str:
+    digest = hashlib.sha256(_content_fields(receipt).encode("utf-8")).hexdigest()
+    return digest[:_PREFIX_CHARS]
+
+
+def mint(
+    claim: Intent,
+    emission: Intent,
+    outcome: DecisionOutcome,
+    outcome_gate: str = "",
+    ruleset_version: str = "",
+    derivation: DecisionDerivation | None = None,
+) -> DecisionReceipt:
+    """
+    Build the receipt for one decision.
+
+    `claim` is what the Transformer proposed; `emission` is what is actually
+    being sent. Passing the same Intent for both is correct when the Membrane
+    changed nothing — the two hashes agreeing is then a fact a reader can check,
+    not an assumption.
+    """
+    receipt = DecisionReceipt(
+        version=RECEIPT_VERSION,
+        claim_hash=claim_digest(claim),
+        ruleset_version=ruleset_version,
+        emission_hash=claim_digest(emission),
+        outcome=outcome,
+        outcome_gate=outcome_gate,
+    )
+    if derivation is not None:
+        receipt.derivation = derivation
+
+    receipt.canonical_prefix = _prefix(receipt)
+    return receipt
+
+
+def verify(receipt: DecisionReceipt) -> VerificationResult:
+    """
+    Re-derive everything checkable without a key, and say what was skipped.
+
+    An unrecognised format version is refused outright rather than checked on a
+    best-effort basis. A future signed receipt read by this code would have its
+    signature ignored, and answering `ok` on it is exactly the downgrade the
+    version string exists to prevent.
+    """
+    if receipt.version != RECEIPT_VERSION:
+        return VerificationResult(
+            ok=False,
+            failures=(
+                f"unknown receipt version {receipt.version!r}; "
+                f"this verifier only reads {RECEIPT_VERSION}",
+            ),
+        )
+
+    failures: list[str] = []
+
+    if receipt.canonical_prefix != _prefix(receipt):
+        failures.append("canonical prefix does not match the content fields")
+
+    derivation = receipt.derivation or DecisionDerivation()
+    if derivation.gate_sequence or derivation.derivation_hash:
+        expected = hashlib.sha256(derivation.gate_sequence.encode("utf-8")).hexdigest()
+        if derivation.derivation_hash != expected:
+            failures.append("derivation hash does not match the recorded gate sequence")
+
+    changed = receipt.claim_hash != receipt.emission_hash
+
+    if receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE and not changed:
+        # A prose-only gate legitimately leaves the two equal, because prose is
+        # outside the claim. Any other gate claiming a substitution that left no
+        # trace is a receipt describing something that did not happen.
+        if receipt.outcome_gate not in _PROSE_ONLY_GATES:
+            failures.append(
+                "override recorded but claim and emission hash alike, and "
+                f"{receipt.outcome_gate!r} is not a prose-only gate"
+            )
+
+    if receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT and changed:
+        failures.append("emit recorded but the emission does not match the claim")
+
+    return VerificationResult(
+        ok=not failures,
+        failures=tuple(failures),
+        # Named rather than counted, so a caller reads what is missing instead
+        # of a number they have to look up.
+        unverifiable=("signature", "premises", "policy"),
+        attested=False,
+    )

--- a/core/src/aura_hive/hive/proteins/guard/skill.py
+++ b/core/src/aura_hive/hive/proteins/guard/skill.py
@@ -12,19 +12,30 @@ from .schema import SafePriceParams, ValidationParams, VisionValidationParams
 logger = logging.getLogger(__name__)
 
 
-def _derivation_fields(derivation: "Derivation | None") -> dict[str, str]:
+def _derivation_fields(
+    derivation: "Derivation | None", ruleset_version: str = ""
+) -> dict[str, str]:
     """
     The record, flattened for Observation metadata.
 
     Empty strings when nothing was derived rather than omitted keys, so the
-    Membrane reads the same two names on every path and cannot mistake "no gate
-    ran" for "the skill forgot to say".
+    Membrane reads the same names on every path and cannot mistake "no gate ran"
+    for "the skill forgot to say".
+
+    `ruleset_version` rides along because it answers the question the record
+    raises: a sequence of gate ids means nothing without saying which rule set
+    those ids belong to.
     """
     if derivation is None:
-        return {"gate_sequence": "", "derivation_hash": ""}
+        return {
+            "gate_sequence": "",
+            "derivation_hash": "",
+            "ruleset_version": ruleset_version,
+        }
     return {
         "gate_sequence": derivation.canonical,
         "derivation_hash": derivation.digest,
+        "ruleset_version": ruleset_version,
     }
 
 
@@ -99,7 +110,9 @@ class GuardSkill(
                     {
                         "error_code": code,
                         "safe_price": str(safe_p),
-                        **_derivation_fields(e.derivation),
+                        **_derivation_fields(
+                            e.derivation, self.provider.ruleset.version_string
+                        ),
                     }
                 ),
             )
@@ -118,7 +131,10 @@ class GuardSkill(
             raise self.provider.violation_for(derivation)
 
         return Observation(
-            success=True, metadata=make_struct(_derivation_fields(derivation))
+            success=True,
+            metadata=make_struct(
+                _derivation_fields(derivation, self.provider.ruleset.version_string)
+            ),
         )
 
     async def _get_safe_price(self, params: dict[str, Any]) -> Observation:

--- a/core/tests/test_membrane_derivation.py
+++ b/core/tests/test_membrane_derivation.py
@@ -28,6 +28,7 @@ from aura_core_gen.aura.core.v1 import (
     ValidationScore,
 )
 from aura_hive.hive.membrane.main import HiveMembrane
+from aura_hive.hive.membrane.receipt import verify
 from aura_hive.hive.proteins.guard import GuardSkill
 from aura_hive.hive.proteins.guard.engine import OutputGuard
 
@@ -73,10 +74,12 @@ class TestTheDerivationReachesTheIntent:
             counter_intent(price=2000.0), negotiation_context()
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
-        assert decision.derivation.gate_sequence.startswith("G1_PRICE_POSITIVE:pass:")
-        assert "G4_MARGIN_VIOLATION:pass:" in decision.derivation.gate_sequence
-        assert len(decision.derivation.derivation_hash) == 64
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+        assert decision.receipt.derivation.gate_sequence.startswith(
+            "G1_PRICE_POSITIVE:pass:"
+        )
+        assert "G4_MARGIN_VIOLATION:pass:" in decision.receipt.derivation.gate_sequence
+        assert len(decision.receipt.derivation.derivation_hash) == 64
 
     @pytest.mark.asyncio
     async def test_an_overridden_decision_carries_the_gate_that_stopped_it(
@@ -92,11 +95,11 @@ class TestTheDerivationReachesTheIntent:
             counter_intent(price=500.0), negotiation_context()
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
-        assert decision.derivation.gate_sequence == (
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
+        assert decision.receipt.derivation.gate_sequence == (
             "G1_PRICE_POSITIVE:pass:price\x1fG2_FLOOR_VIOLATION:fail:price,floor_price"
         )
-        assert len(decision.derivation.derivation_hash) == 64
+        assert len(decision.receipt.derivation.derivation_hash) == 64
 
     @pytest.mark.asyncio
     async def test_the_hash_matches_the_sequence_that_travelled(self) -> None:
@@ -113,9 +116,9 @@ class TestTheDerivationReachesTheIntent:
         )
 
         assert (
-            decision.derivation.derivation_hash
+            decision.receipt.derivation.derivation_hash
             == hashlib.sha256(
-                decision.derivation.gate_sequence.encode("utf-8")
+                decision.receipt.derivation.gate_sequence.encode("utf-8")
             ).hexdigest()
         )
 
@@ -143,8 +146,14 @@ class TestReplay:
             counter_intent(price=price), negotiation_context()
         )
 
-        assert first.derivation.gate_sequence == second.derivation.gate_sequence
-        assert first.derivation.derivation_hash == second.derivation.derivation_hash
+        assert (
+            first.receipt.derivation.gate_sequence
+            == second.receipt.derivation.gate_sequence
+        )
+        assert (
+            first.receipt.derivation.derivation_hash
+            == second.receipt.derivation.derivation_hash
+        )
 
     @pytest.mark.asyncio
     async def test_a_different_floor_changing_the_verdict_changes_the_digest(
@@ -161,7 +170,10 @@ class TestReplay:
             counter_intent(price=1500.0), negotiation_context(floor_price=9000.0)
         )
 
-        assert passing.derivation.derivation_hash != failing.derivation.derivation_hash
+        assert (
+            passing.receipt.derivation.derivation_hash
+            != failing.receipt.derivation.derivation_hash
+        )
 
     @pytest.mark.asyncio
     async def test_a_different_floor_leaving_the_verdict_alone_does_not(self) -> None:
@@ -177,7 +189,10 @@ class TestReplay:
             counter_intent(price=5000.0), negotiation_context(floor_price=2000.0)
         )
 
-        assert low.derivation.derivation_hash == high.derivation.derivation_hash
+        assert (
+            low.receipt.derivation.derivation_hash
+            == high.receipt.derivation.derivation_hash
+        )
 
 
 class TestTheIntentNeverCarriesAValue:
@@ -195,7 +210,7 @@ class TestTheIntentNeverCarriesAValue:
             counter_intent(price=price), negotiation_context(floor_price=FLOOR)
         )
 
-        sequence = decision.derivation.gate_sequence
+        sequence = decision.receipt.derivation.gate_sequence
         for secret in ("1000", "777", str(price), str(int(price))):
             assert secret not in sequence
 
@@ -244,8 +259,8 @@ class TestAGuardThatReportsNothingUsable:
             counter_intent(price=2000.0), negotiation_context()
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
-        assert decision.derivation.derivation_hash == ""
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+        assert decision.receipt.derivation.derivation_hash == ""
 
     @pytest.mark.asyncio
     async def test_a_null_valued_record_is_not_attached_as_the_word_none(self) -> None:
@@ -265,8 +280,8 @@ class TestAGuardThatReportsNothingUsable:
             counter_intent(price=2000.0), negotiation_context()
         )
 
-        assert decision.derivation.gate_sequence == ""
-        assert decision.derivation.derivation_hash == ""
+        assert decision.receipt.derivation.gate_sequence == ""
+        assert decision.receipt.derivation.derivation_hash == ""
 
 
 class TestNoDeclaredGateRan:
@@ -293,9 +308,9 @@ class TestNoDeclaredGateRan:
 
         decision = await membrane.inspect_outbound(intent, negotiation_context())
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_REFUSE
-        assert decision.derivation.gate_sequence == ""
-        assert decision.derivation.derivation_hash == ""
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_REFUSE
+        assert decision.receipt.derivation.gate_sequence == ""
+        assert decision.receipt.derivation.derivation_hash == ""
 
     @pytest.mark.asyncio
     async def test_a_high_risk_trade_refusal_shows_no_derivation(self) -> None:
@@ -311,7 +326,7 @@ class TestNoDeclaredGateRan:
 
         decision = await membrane.inspect_outbound(intent, negotiation_context())
 
-        assert decision.derivation.derivation_hash == ""
+        assert decision.receipt.derivation.derivation_hash == ""
 
     @pytest.mark.asyncio
     async def test_a_model_reject_shows_no_derivation(self) -> None:
@@ -326,8 +341,8 @@ class TestNoDeclaredGateRan:
             negotiation_context(),
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
-        assert decision.derivation.derivation_hash == ""
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+        assert decision.receipt.derivation.derivation_hash == ""
 
     @pytest.mark.asyncio
     async def test_an_unwired_membrane_shows_no_derivation(self) -> None:
@@ -342,5 +357,100 @@ class TestNoDeclaredGateRan:
             counter_intent(price=2000.0), negotiation_context()
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
-        assert decision.derivation.derivation_hash == ""
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+        assert decision.receipt.derivation.derivation_hash == ""
+
+
+class TestTheReceiptTheMembraneMints:
+    """
+    End-to-end: the receipt on a real emitted Intent should survive the
+    verifier, which is the only claim any of this makes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_it_names_the_rule_set_that_judged_the_decision(self) -> None:
+        decision = await guarded_membrane().inspect_outbound(
+            counter_intent(price=2000.0), negotiation_context()
+        )
+
+        assert decision.receipt.ruleset_version.startswith("guard/negotiation@")
+
+    @pytest.mark.asyncio
+    async def test_a_decision_no_rule_set_judged_names_none(self) -> None:
+        """
+        An empty version rather than a plausible-looking default: the KYC path
+        consults no rule set, and naming one would be a claim about how the
+        decision was reached that is simply untrue.
+        """
+        decision = await guarded_membrane().inspect_outbound(
+            Intent(
+                action=ActionType.ACTION_TYPE_APPROVE,
+                rwa_vault=RWAVaultIntent(
+                    wallet_address="0xdead",
+                    compliance=RWAComplianceScore(kyc_passed=False),
+                ),
+            ),
+            negotiation_context(),
+        )
+
+        assert decision.receipt.ruleset_version == ""
+        assert decision.receipt.outcome_gate == "KYC_FAILURE"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("price", [500.0, 2000.0])
+    async def test_the_minted_receipt_verifies(self, price: float) -> None:
+        decision = await guarded_membrane().inspect_outbound(
+            counter_intent(price=price), negotiation_context()
+        )
+
+        result = verify(decision.receipt)
+
+        assert result.ok, result.failures
+
+    @pytest.mark.asyncio
+    async def test_an_override_is_visible_as_two_differing_hashes(self) -> None:
+        """
+        The property the claim/emission pair exists for. A reader compares two
+        hex strings and knows the price they were given is the guard's, not the
+        model's — without being told, and without trusting the telling.
+        """
+        decision = await guarded_membrane().inspect_outbound(
+            counter_intent(price=500.0), negotiation_context()
+        )
+
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
+        assert decision.receipt.claim_hash != decision.receipt.emission_hash
+
+    @pytest.mark.asyncio
+    async def test_an_untouched_decision_shows_two_matching_hashes(self) -> None:
+        decision = await guarded_membrane().inspect_outbound(
+            counter_intent(price=2000.0), negotiation_context()
+        )
+
+        assert decision.receipt.claim_hash == decision.receipt.emission_hash
+
+    @pytest.mark.asyncio
+    async def test_the_receipt_never_carries_a_hidden_number(self) -> None:
+        """
+        Every field at once, not just the gate sequence: the receipt is the
+        artefact meant to leave the building.
+        """
+        decision = await guarded_membrane().inspect_outbound(
+            counter_intent(price=500.0), negotiation_context(floor_price=FLOOR)
+        )
+        r = decision.receipt
+        rendered = " ".join(
+            [
+                r.version,
+                r.claim_hash,
+                r.ruleset_version,
+                r.emission_hash,
+                r.outcome_gate,
+                r.canonical_prefix,
+                r.derivation.gate_sequence,
+                r.derivation.derivation_hash,
+            ]
+        )
+
+        for secret in ("1000", "777", "500", "1050"):
+            assert secret not in rendered

--- a/core/tests/test_membrane_derivation.py
+++ b/core/tests/test_membrane_derivation.py
@@ -454,3 +454,46 @@ class TestTheReceiptTheMembraneMints:
 
         for secret in ("1000", "777", "500", "1050"):
             assert secret not in rendered
+
+
+class TestAContextWithNullNumbers:
+    """
+    A Struct round-trips a JSON null back as None, and the outbound path read
+    `float(str(ctx_meta.get(...)))` — so `float("None")` raised ValueError.
+
+    Nothing catches it. `MetabolicLoop.execute` wraps neither membrane call, so
+    the exception leaves the cycle entirely and the negotiation is lost. That is
+    the wrong failure for the component whose whole job is to be the thing that
+    does not let a bad decision out: refusing safely is its business, crashing
+    is not.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_null_floor_does_not_crash_the_outbound_path(self) -> None:
+        decision = await guarded_membrane().inspect_outbound(
+            counter_intent(price=2000.0),
+            Context(metadata=make_struct({"floor_price": None})),
+        )
+
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+
+    @pytest.mark.asyncio
+    async def test_a_null_cost_does_not_crash_the_outbound_path(self) -> None:
+        decision = await guarded_membrane().inspect_outbound(
+            counter_intent(price=2000.0),
+            Context(
+                metadata=make_struct({"floor_price": "1000.0", "internal_cost": None})
+            ),
+        )
+
+        assert decision.receipt.derivation.derivation_hash != ""
+
+    @pytest.mark.asyncio
+    async def test_an_unparseable_floor_does_not_crash_either(self) -> None:
+        """Same failure, different input: the guard is not a parser."""
+        decision = await guarded_membrane().inspect_outbound(
+            counter_intent(price=2000.0),
+            Context(metadata=make_struct({"floor_price": "not a number"})),
+        )
+
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT

--- a/core/tests/test_membrane_outcome.py
+++ b/core/tests/test_membrane_outcome.py
@@ -75,8 +75,8 @@ class TestEmit:
             counter_intent(price=2000.0), negotiation_context(floor_price=1000.0)
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
-        assert decision.outcome_gate == ""
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+        assert decision.receipt.outcome_gate == ""
 
     @pytest.mark.asyncio
     async def test_a_decision_the_guard_never_saw_is_still_marked_emit(self) -> None:
@@ -91,7 +91,7 @@ class TestEmit:
             counter_intent(price=2000.0), negotiation_context(floor_price=1000.0)
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
 
 
 class TestOverride:
@@ -103,8 +103,8 @@ class TestOverride:
             counter_intent(price=500.0), negotiation_context(floor_price=1000.0)
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
-        assert decision.outcome_gate == "FLOOR_PRICE_VIOLATION"
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
+        assert decision.receipt.outcome_gate == "FLOOR_PRICE_VIOLATION"
 
     @pytest.mark.asyncio
     async def test_the_substituted_price_travels_with_the_override_mark(self) -> None:
@@ -115,7 +115,7 @@ class TestOverride:
             counter_intent(price=500.0), negotiation_context(floor_price=1000.0)
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
         assert decision.negotiation.price != 500.0
 
     @pytest.mark.asyncio
@@ -131,8 +131,8 @@ class TestOverride:
             negotiation_context(floor_price=1000.0),
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
-        assert decision.outcome_gate == "DLP_BLOCK"
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
+        assert decision.receipt.outcome_gate == "DLP_BLOCK"
 
     @pytest.mark.asyncio
     async def test_the_first_gate_to_fire_is_the_one_recorded(self) -> None:
@@ -155,7 +155,7 @@ class TestOverride:
             negotiation_context(floor_price=1000.0),
         )
 
-        assert decision.outcome_gate == "DLP_BLOCK"
+        assert decision.receipt.outcome_gate == "DLP_BLOCK"
         # The later gate still ran: the price was replaced, not merely flagged.
         assert decision.negotiation.price != 500.0
 
@@ -176,8 +176,8 @@ class TestRefuse:
 
         decision = await membrane.inspect_outbound(intent, negotiation_context())
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_REFUSE
-        assert decision.outcome_gate == "KYC_FAILURE"
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_REFUSE
+        assert decision.receipt.outcome_gate == "KYC_FAILURE"
         assert decision.action == ActionType.ACTION_TYPE_REJECT
 
     @pytest.mark.asyncio
@@ -194,8 +194,8 @@ class TestRefuse:
 
         decision = await membrane.inspect_outbound(intent, negotiation_context())
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_REFUSE
-        assert decision.outcome_gate == "HIGH_RISK_TRADE"
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_REFUSE
+        assert decision.receipt.outcome_gate == "HIGH_RISK_TRADE"
         assert decision.action == ActionType.ACTION_TYPE_REJECT
 
     @pytest.mark.asyncio
@@ -210,8 +210,8 @@ class TestRefuse:
 
         decision = await membrane.inspect_outbound(intent, negotiation_context())
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
-        assert decision.outcome_gate == ""
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+        assert decision.receipt.outcome_gate == ""
 
 
 class TestFailureRecovery:
@@ -229,8 +229,8 @@ class TestFailureRecovery:
             negotiation_context(floor_price=1000.0),
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
-        assert decision.outcome_gate == "FAILURE_RECOVERY"
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
+        assert decision.receipt.outcome_gate == "FAILURE_RECOVERY"
 
 
 class TestReplacementPreservesIdentity:
@@ -260,7 +260,7 @@ class TestReplacementPreservesIdentity:
             original, negotiation_context(floor_price=1000.0)
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
         assert decision.identifier == "decision-42"
         assert decision.trace.trace_id == "0af7651916cd43dd"
 
@@ -279,7 +279,7 @@ class TestReplacementPreservesIdentity:
 
         decision = await membrane.inspect_outbound(original, negotiation_context())
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_REFUSE
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_REFUSE
         assert decision.identifier == "decision-43"
         assert decision.trace.trace_id == "0af7651916cd43dd"
 
@@ -301,7 +301,7 @@ class TestReplacementPreservesIdentity:
 
         decision = await membrane.inspect_outbound(original, negotiation_context())
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_REFUSE
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_REFUSE
         assert decision.identifier == "decision-44"
         assert decision.trace.trace_id == "0af7651916cd43dd"
 
@@ -326,5 +326,5 @@ class TestPassThrough:
             negotiation_context(floor_price=1000.0),
         )
 
-        assert decision.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
-        assert decision.outcome_gate == ""
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+        assert decision.receipt.outcome_gate == ""

--- a/core/tests/test_receipt.py
+++ b/core/tests/test_receipt.py
@@ -24,10 +24,12 @@ from aura_core_gen.aura.core.v1 import (
     DecisionOutcome,
     Intent,
     NegotiationIntent,
+    RWAVaultIntent,
     TradeIntent,
 )
 from aura_hive.hive.membrane.receipt import (
     RECEIPT_VERSION,
+    _prefix,
     canonical_claim,
     claim_digest,
     mint,
@@ -78,17 +80,112 @@ class TestTheCanonicalClaim:
             counter(price=106.0)
         )
 
-    def test_a_non_negotiation_intent_records_its_shape(self) -> None:
+    def test_a_trade_names_the_trade_it_decided(self) -> None:
         """
-        Trade and vault decisions have no price field to canonicalise here. The
-        claim still has to distinguish them from a negotiation, or two unrelated
-        decisions would hash alike.
+        The first cut recorded only the shape — `action=approve;params=trade` for
+        every trade there has ever been. That distinguished a trade from a
+        negotiation and stopped there, which is the wrong half of the job: a
+        digest of "the decision the Transformer proposed" that is identical for a
+        ten-dollar trade and a nine-million-dollar one does not identify a
+        decision at all.
         """
         trade = Intent(
-            action=ActionType.ACTION_TYPE_APPROVE, trade=TradeIntent(trade_id="t-1")
+            action=ActionType.ACTION_TYPE_APPROVE,
+            trade=TradeIntent(
+                trade_id="t-1",
+                asset_identifier="AURA",
+                proposed_price=10.0,
+                currency_code="USD",
+            ),
         )
 
-        assert canonical_claim(trade) == "action=approve;params=trade"
+        assert canonical_claim(trade) == (
+            "action=approve;params=trade;trade=t-1;asset=AURA;price=10.00;currency=USD"
+        )
+
+    def test_two_different_trades_do_not_hash_alike(self) -> None:
+        """
+        Harmless while nothing signs a receipt — anyone who can swap one onto
+        another Intent can equally mint a fresh one, since `mint` holds no
+        secret. It stops being harmless the moment a signature makes a receipt
+        worth lifting, so the collision goes now rather than being inherited by
+        the format that has something to protect.
+        """
+        cheap = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            trade=TradeIntent(
+                trade_id="t-1", asset_identifier="A", proposed_price=10.0
+            ),
+        )
+        dear = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            trade=TradeIntent(
+                trade_id="t-999", asset_identifier="B", proposed_price=9_000_000.0
+            ),
+        )
+
+        assert claim_digest(cheap) != claim_digest(dear)
+
+    def test_a_vault_names_the_vault_it_decided(self) -> None:
+        vault = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            rwa_vault=RWAVaultIntent(
+                vault_id="v-1",
+                asset_identifier="DEED-7",
+                appraised_value_usd=250_000.0,
+                ltv_ratio=0.6,
+                wallet_address="0xabc",
+            ),
+        )
+
+        assert canonical_claim(vault) == (
+            "action=approve;params=rwa_vault;vault=v-1;asset=DEED-7;"
+            "appraised=250000.00;ltv=0.6000;wallet=0xabc"
+        )
+
+    def test_two_vaults_against_different_wallets_do_not_hash_alike(self) -> None:
+        """Same collateral, different beneficiary, is a different decision."""
+        mine = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            rwa_vault=RWAVaultIntent(vault_id="v-1", wallet_address="0xaaa"),
+        )
+        theirs = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            rwa_vault=RWAVaultIntent(vault_id="v-1", wallet_address="0xbbb"),
+        )
+
+        assert claim_digest(mine) != claim_digest(theirs)
+
+    def test_a_trade_and_a_vault_still_do_not_hash_alike(self) -> None:
+        """The original property, kept: the shape is still part of the claim."""
+        trade = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE, trade=TradeIntent(trade_id="x")
+        )
+        vault = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            rwa_vault=RWAVaultIntent(vault_id="x"),
+        )
+
+        assert claim_digest(trade) != claim_digest(vault)
+
+    def test_an_intent_with_no_params_records_that(self) -> None:
+        """The FAILURE_RECOVERY path reaches here with a bare ERROR Intent."""
+        assert (
+            canonical_claim(Intent(action=ActionType.ACTION_TYPE_ERROR))
+            == "action=error;params=none"
+        )
+
+    def test_trade_prose_is_excluded_like_any_other(self) -> None:
+        terse = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            trade=TradeIntent(trade_id="t-1", reasoning="short"),
+        )
+        florid = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            trade=TradeIntent(trade_id="t-1", reasoning="a much longer explanation"),
+        )
+
+        assert canonical_claim(terse) == canonical_claim(florid)
 
     def test_the_digest_is_a_full_sha256_of_the_canonical_claim(self) -> None:
         intent = counter(price=105.0)
@@ -308,6 +405,21 @@ class TestVerifyIsHonestAboutWhatItCannotCheck:
 
         assert not result.ok
         assert any("emit" in failure for failure in result.failures)
+
+    def test_an_unspecified_outcome_is_caught(self) -> None:
+        """
+        Zero is protobuf's default, so an outcome nobody set is indistinguishable
+        from a field that was never written. A receipt whose central claim is
+        absent should not pass for one that merely had nothing go wrong.
+        """
+        receipt = self.base_receipt()
+        receipt.outcome = DecisionOutcome.DECISION_OUTCOME_UNSPECIFIED
+        receipt.canonical_prefix = _prefix(receipt)
+
+        result = verify(receipt)
+
+        assert not result.ok
+        assert any("unspecified" in failure for failure in result.failures)
 
     def test_an_unknown_format_version_is_refused_outright(self) -> None:
         """

--- a/core/tests/test_receipt.py
+++ b/core/tests/test_receipt.py
@@ -1,0 +1,324 @@
+"""
+What the Membrane can attest about a decision, and what it cannot.
+
+The receipt gathers into one place what the previous three steps produced —
+which rules judged the decision, how they were applied, what the verdict was —
+and adds the pair that makes the intervention checkable: a digest of what the
+model proposed and a digest of what was actually sent. Those two differing IS
+the override, stated as a fact a reader can verify rather than a claim they must
+take on trust.
+
+It is deliberately not called a receipt in the spec's sense. VISION §5.1.7 holds
+that an unsigned receipt is not a receipt regardless of any other field, and
+neither the signature nor the premise hash exists yet. The format identifier says
+UNSIGNED so nothing can mistake this for the attested article, and `verify` is
+explicit about which checks it did not perform.
+"""
+
+import hashlib
+
+import pytest
+from aura_core_gen.aura.core.v1 import (
+    ActionType,
+    DecisionDerivation,
+    DecisionOutcome,
+    Intent,
+    NegotiationIntent,
+    TradeIntent,
+)
+from aura_hive.hive.membrane.receipt import (
+    RECEIPT_VERSION,
+    canonical_claim,
+    claim_digest,
+    mint,
+    verify,
+)
+
+
+def counter(price: float, item: str = "htl-9931", message: str = "an offer") -> Intent:
+    return Intent(
+        action=ActionType.ACTION_TYPE_COUNTER,
+        reasoning="the model's private reasoning",
+        negotiation=NegotiationIntent(
+            item_identifier=item, price=price, message=message, thought="a thought"
+        ),
+    )
+
+
+class TestTheCanonicalClaim:
+    def test_it_names_the_decidable_content(self) -> None:
+        assert canonical_claim(counter(price=105.0)) == (
+            "action=counter;item=htl-9931;price=105.00"
+        )
+
+    def test_prose_is_excluded(self) -> None:
+        """
+        `reasoning`, `message` and `thought` are the model's free text. Hashing
+        them would make the digest irreproducible for anyone who did not receive
+        the exact string, and they are not what the decision decides.
+        """
+        terse = counter(price=105.0, message="hi")
+        florid = counter(price=105.0, message="I have thought about this at length")
+        florid.reasoning = "an entirely different explanation"
+
+        assert canonical_claim(terse) == canonical_claim(florid)
+
+    def test_the_price_is_formatted_to_a_fixed_precision(self) -> None:
+        """
+        A float rendered by repr is not stable enough to hash: 105.0 and 105.00
+        and 105.000000001 must not be three different claims, and the last of
+        those is what arithmetic hands you.
+        """
+        assert "price=105.00" in canonical_claim(counter(price=105.0))
+        assert "price=105.00" in canonical_claim(counter(price=105.004))
+        assert "price=0.10" in canonical_claim(counter(price=0.1))
+
+    def test_a_different_price_is_a_different_claim(self) -> None:
+        assert canonical_claim(counter(price=105.0)) != canonical_claim(
+            counter(price=106.0)
+        )
+
+    def test_a_non_negotiation_intent_records_its_shape(self) -> None:
+        """
+        Trade and vault decisions have no price field to canonicalise here. The
+        claim still has to distinguish them from a negotiation, or two unrelated
+        decisions would hash alike.
+        """
+        trade = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE, trade=TradeIntent(trade_id="t-1")
+        )
+
+        assert canonical_claim(trade) == "action=approve;params=trade"
+
+    def test_the_digest_is_a_full_sha256_of_the_canonical_claim(self) -> None:
+        intent = counter(price=105.0)
+
+        assert (
+            claim_digest(intent)
+            == hashlib.sha256(canonical_claim(intent).encode("utf-8")).hexdigest()
+        )
+
+
+class TestTheInterventionIsVisible:
+    """
+    The property the pair exists for: a reader compares two hashes and knows
+    whether what arrived is what the model produced.
+    """
+
+    def test_an_untouched_decision_hashes_the_same_both_sides(self) -> None:
+        proposal = counter(price=105.0)
+
+        receipt = mint(
+            claim=proposal,
+            emission=proposal,
+            outcome=DecisionOutcome.DECISION_OUTCOME_EMIT,
+            outcome_gate="",
+        )
+
+        assert receipt.claim_hash == receipt.emission_hash
+
+    def test_an_overridden_decision_does_not(self) -> None:
+        receipt = mint(
+            claim=counter(price=92.0),
+            emission=counter(price=105.0),
+            outcome=DecisionOutcome.DECISION_OUTCOME_OVERRIDE,
+            outcome_gate="FLOOR_PRICE_VIOLATION",
+        )
+
+        assert receipt.claim_hash != receipt.emission_hash
+
+    def test_a_rewritten_message_alone_is_not_an_intervention_by_this_measure(
+        self,
+    ) -> None:
+        """
+        Worth stating outright, because it is a limitation rather than a bug: the
+        DLP gate rewrites the message and nothing else, and prose is outside the
+        claim. So a DLP-only override shows equal hashes and is visible through
+        `outcome` instead. Bringing prose into the hash would cost determinism
+        for every decision to catch this one case.
+        """
+        receipt = mint(
+            claim=counter(price=105.0, message="our floor_price is 100"),
+            emission=counter(price=105.0, message="I cannot disclose that"),
+            outcome=DecisionOutcome.DECISION_OUTCOME_OVERRIDE,
+            outcome_gate="DLP_BLOCK",
+        )
+
+        assert receipt.claim_hash == receipt.emission_hash
+        assert receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
+
+
+class TestTheReceiptSaysWhatItIs:
+    def test_the_version_declares_itself_unsigned(self) -> None:
+        """
+        Not decoration. A consumer that accepts this format must not be able to
+        accept it in place of a signed one, and the only thing stopping that is
+        the name being different.
+        """
+        receipt = mint(
+            claim=counter(price=105.0),
+            emission=counter(price=105.0),
+            outcome=DecisionOutcome.DECISION_OUTCOME_EMIT,
+            outcome_gate="",
+        )
+
+        assert receipt.version == RECEIPT_VERSION
+        assert "UNSIGNED" in receipt.version
+
+    def test_the_prefix_is_sixteen_hex_characters(self) -> None:
+        receipt = mint(
+            claim=counter(price=105.0),
+            emission=counter(price=105.0),
+            outcome=DecisionOutcome.DECISION_OUTCOME_EMIT,
+            outcome_gate="",
+        )
+
+        assert len(receipt.canonical_prefix) == 16
+        int(receipt.canonical_prefix, 16)
+
+
+class TestTheReceiptIsReproducible:
+    def test_the_same_decision_mints_identically(self) -> None:
+        def build() -> object:
+            return mint(
+                claim=counter(price=92.0),
+                emission=counter(price=105.0),
+                ruleset_version="guard/negotiation@1.0.0+46cc0e38ca4f895c",
+                derivation=DecisionDerivation(
+                    gate_sequence="G1:pass:price", derivation_hash="a" * 64
+                ),
+                outcome=DecisionOutcome.DECISION_OUTCOME_OVERRIDE,
+                outcome_gate="FLOOR_PRICE_VIOLATION",
+            )
+
+        assert build() == build()
+
+    @pytest.mark.parametrize(
+        "changed",
+        ["ruleset_version", "outcome", "outcome_gate", "emission"],
+    )
+    def test_changing_any_content_field_moves_the_prefix(self, changed: str) -> None:
+        base = {
+            "claim": counter(price=92.0),
+            "emission": counter(price=105.0),
+            "ruleset_version": "guard/negotiation@1.0.0+46cc0e38ca4f895c",
+            "outcome": DecisionOutcome.DECISION_OUTCOME_OVERRIDE,
+            "outcome_gate": "FLOOR_PRICE_VIOLATION",
+        }
+        altered = dict(base)
+        altered[changed] = {
+            "ruleset_version": "guard/negotiation@2.0.0+0000000000000000",
+            "outcome": DecisionOutcome.DECISION_OUTCOME_REFUSE,
+            "outcome_gate": "MIN_MARGIN_VIOLATION",
+            "emission": counter(price=999.0),
+        }[changed]
+
+        assert mint(**base).canonical_prefix != mint(**altered).canonical_prefix
+
+
+class TestVerifyIsHonestAboutWhatItCannotCheck:
+    def base_receipt(self) -> object:
+        return mint(
+            claim=counter(price=92.0),
+            emission=counter(price=105.0),
+            ruleset_version="guard/negotiation@1.0.0+46cc0e38ca4f895c",
+            derivation=DecisionDerivation(
+                gate_sequence="G1_PRICE_POSITIVE:pass:price",
+                derivation_hash=hashlib.sha256(
+                    b"G1_PRICE_POSITIVE:pass:price"
+                ).hexdigest(),
+            ),
+            outcome=DecisionOutcome.DECISION_OUTCOME_OVERRIDE,
+            outcome_gate="FLOOR_PRICE_VIOLATION",
+        )
+
+    def test_a_well_formed_receipt_passes_every_check_it_can_run(self) -> None:
+        result = verify(self.base_receipt())
+
+        assert result.ok
+        assert result.failures == ()
+
+    def test_it_names_the_checks_it_could_not_perform(self) -> None:
+        """
+        The point of the whole exercise. A verifier that returns a bare "valid"
+        while silently skipping the integrity check teaches its consumer to trust
+        a guarantee nobody made.
+        """
+        result = verify(self.base_receipt())
+
+        assert "signature" in result.unverifiable
+        assert "premises" in result.unverifiable
+        assert not result.attested
+
+    def test_a_tampered_prefix_is_caught(self) -> None:
+        receipt = self.base_receipt()
+        receipt.canonical_prefix = "0" * 16
+
+        result = verify(receipt)
+
+        assert not result.ok
+        assert any("prefix" in failure for failure in result.failures)
+
+    def test_a_derivation_hash_that_does_not_match_its_sequence_is_caught(self) -> None:
+        receipt = self.base_receipt()
+        receipt.derivation.gate_sequence = "G9_INVENTED:pass:"
+
+        result = verify(receipt)
+
+        assert not result.ok
+        assert any("derivation" in failure for failure in result.failures)
+
+    def test_an_override_whose_hashes_agree_is_caught(self) -> None:
+        """
+        A receipt claiming the Membrane substituted a value while showing the
+        emission identical to the claim is internally inconsistent — except for
+        the prose-only case, which is why the check reads the gate.
+        """
+        receipt = mint(
+            claim=counter(price=105.0),
+            emission=counter(price=105.0),
+            outcome=DecisionOutcome.DECISION_OUTCOME_OVERRIDE,
+            outcome_gate="FLOOR_PRICE_VIOLATION",
+        )
+
+        result = verify(receipt)
+
+        assert not result.ok
+        assert any("override" in failure for failure in result.failures)
+
+    def test_a_prose_only_override_is_not_flagged(self) -> None:
+        receipt = mint(
+            claim=counter(price=105.0),
+            emission=counter(price=105.0),
+            outcome=DecisionOutcome.DECISION_OUTCOME_OVERRIDE,
+            outcome_gate="DLP_BLOCK",
+        )
+
+        assert verify(receipt).ok
+
+    def test_an_emit_whose_hashes_differ_is_caught(self) -> None:
+        receipt = mint(
+            claim=counter(price=92.0),
+            emission=counter(price=105.0),
+            outcome=DecisionOutcome.DECISION_OUTCOME_EMIT,
+            outcome_gate="",
+        )
+
+        result = verify(receipt)
+
+        assert not result.ok
+        assert any("emit" in failure for failure in result.failures)
+
+    def test_an_unknown_format_version_is_refused_outright(self) -> None:
+        """
+        Refusing rather than best-effort checking. A future signed format read by
+        this code would have its signature ignored, and reporting `ok` on it is
+        the downgrade the version string exists to prevent.
+        """
+        receipt = self.base_receipt()
+        receipt.version = "AURA-RECEIPT-V1"
+
+        result = verify(receipt)
+
+        assert not result.ok
+        assert any("version" in failure for failure in result.failures)

--- a/core/tests/test_receipt.py
+++ b/core/tests/test_receipt.py
@@ -20,6 +20,7 @@ import hashlib
 import pytest
 from aura_core_gen.aura.core.v1 import (
     ActionType,
+    AssetIntent,
     DecisionDerivation,
     DecisionOutcome,
     Intent,
@@ -434,3 +435,51 @@ class TestVerifyIsHonestAboutWhatItCannotCheck:
 
         assert not result.ok
         assert any("version" in failure for failure in result.failures)
+
+
+class TestTheAssetClaimAlsoNamesItsDecision:
+    """
+    The same collision `trade` and `rwa_vault` had. Fixing two of the three
+    params types that carry outward-facing content and leaving the third is
+    worse than not having noticed: it reads as a decision rather than an
+    oversight.
+    """
+
+    def test_two_different_asset_decisions_do_not_hash_alike(self) -> None:
+        one = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            asset=AssetIntent(asset_identifier="a-1", asset_domain="lodging"),
+        )
+        other = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            asset=AssetIntent(asset_identifier="a-2", asset_domain="lodging"),
+        )
+
+        assert claim_digest(one) != claim_digest(other)
+
+    def test_the_asset_domain_is_part_of_the_claim(self) -> None:
+        """The same identifier in two domains is not the same asset."""
+        lodging = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            asset=AssetIntent(asset_identifier="a-1", asset_domain="lodging"),
+        )
+        vehicles = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            asset=AssetIntent(asset_identifier="a-1", asset_domain="vehicles"),
+        )
+
+        assert claim_digest(lodging) != claim_digest(vehicles)
+
+    def test_it_names_the_asset_it_decided(self) -> None:
+        intent = Intent(
+            action=ActionType.ACTION_TYPE_APPROVE,
+            asset=AssetIntent(
+                asset_identifier="a-1",
+                asset_domain="lodging",
+                action_type=ActionType.ACTION_TYPE_ACCEPT,
+            ),
+        )
+
+        assert canonical_claim(intent) == (
+            "action=approve;params=asset;asset=a-1;domain=lodging;asset_action=accept"
+        )

--- a/docs/DECISION_RECEIPT.md
+++ b/docs/DECISION_RECEIPT.md
@@ -244,13 +244,22 @@ The fix is not to remove the override. It is to **stop hiding it**:
 | `override` | a gate fired; Membrane substituted a deterministic safe value | differ |
 | `refuse` | a gate fired; no emission (KYC failure, high-risk trade) | emission is the reason |
 
-Today the override is recorded only in `_record_intervention()` telemetry and a `[MEMBRANE: …]`
-suffix appended to free-text `reasoning`. Under this design it becomes a typed, signed,
-counterparty-visible fact. That is the single highest-value change in this document and it is
-independently useful even if the rest is never built.
+**Implemented.** The override used to be recorded only in `_record_intervention()` telemetry and a
+`[MEMBRANE: …]` suffix on free-text `reasoning`; it is now a typed, counterparty-visible fact —
+though not yet a signed one.
 
-`refuse` receipts carry a real `derivation-hash` (the hash of the refusal-reason record), not a
-placeholder — a refusal is a closed derivation onto the refusal symbol (VISION §5.1.4).
+Two limits worth stating rather than discovering later:
+
+- **A prose-only override shows equal hashes.** The DLP gate rewrites the message and nothing else,
+  and prose is deliberately outside the claim (§3.2). So a DLP-only override is visible through
+  `outcome` but not through the digests. Bringing prose into the hash would cost determinism on
+  every decision to catch this one case, so `verify` special-cases the gate instead: an override
+  under a non-prose gate whose hashes agree is a receipt describing something that did not happen,
+  and is reported as a failure.
+- **`refuse` receipts carry no derivation.** VISION §5.1.4 wants a real digest there, since a
+  refusal is a closed derivation onto the refusal symbol. Ours are Membrane-level checks (KYC,
+  trade risk) that no rule set declares, so there are no gate ids to record (§3.3). They carry an
+  `outcome_gate` and an empty derivation, which is honest but is a gap against the spec.
 
 ### 3.7 `verifier` and `canonical-prefix`
 
@@ -317,9 +326,25 @@ committed beforehand. What they do not learn: the floor, the margin, the cost.
    and returns the record, which travels on `SafetyViolation` for the failing path. Replay tests
    build a fresh Membrane, registry and guard per run, since anything surviving between them is
    state a verifier does not have. Covered by `core/tests/test_{guard,membrane}_derivation.py`.
-4. Add hashes, salt, split policy stamp.
-5. Sign with the identity key; wire `canonical-prefix` into logs and frontend.
-6. Typed `DecisionReceipt` proto message; bee-keeper verifies receipts in CI audit.
+4. Add `premise-hash` + salt, and split the policy stamp. **Blocked on a decision, not on code**:
+   who holds the salt and how it rotates. Without that the premise hash is either brute-forceable
+   (§3.1) or unverifiable by anyone but us.
+5. Sign with the identity key; wire `canonical-prefix` into logs and frontend. **Blocked on a
+   decision**: which key signs. The wallet-sanctification key is the obvious candidate, since it
+   would bind receipts to the ERC-8004 identity work.
+6. ~~Typed `DecisionReceipt` proto message; bee-keeper verifies receipts in CI audit.~~
+   **PARTLY DONE.** `DecisionReceipt` exists and `Intent.receipt` replaces the three fields that
+   accumulated on `Intent` (7, 8 and 9 are reserved). It adds `claim_hash` / `emission_hash`, so an
+   override is visible as two differing digests rather than a claim to be trusted, and
+   `canonical_prefix`. `membrane/receipt.py` mints and verifies; covered by
+   `core/tests/test_receipt.py`.
 
-Steps 1–3 are the ones that pay for themselves regardless of whether the cryptographic layer ever
-lands.
+   **The bee-keeper half was mis-specified and is not built.** bee.Keeper audits *architecture* —
+   it reads the codebase through an LLM and the VCS protein, and never sees an emitted `Intent`.
+   There are no persisted receipts in CI for it to verify, so "verifies receipts in CI audit" had
+   nothing to run against. Receipt checking is a library function (`verify`) exercised by tests
+   instead. Wiring it into a real audit needs decisions persisted somewhere an auditor can read,
+   which is its own piece of work and not obviously worth doing before the receipts are signed.
+
+Steps 1–3 and 6 pay for themselves regardless of whether the cryptographic layer ever lands. Steps
+4 and 5 each need an answer before any code is worth writing.

--- a/proto/aura/core/v1/metabolism.proto
+++ b/proto/aura/core/v1/metabolism.proto
@@ -226,6 +226,58 @@ message DecisionDerivation {
   string derivation_hash = 2;
 }
 
+// What the Membrane can attest about one decision, in one place.
+//
+// NOT YET A RECEIPT IN THE SENSE THE SPEC MEANS. VISION §5.1.7 is explicit that
+// a receipt without a valid verifier signature is not a receipt regardless of
+// any other field, and the signature (§3.7) and premise hash (§3.1) are not
+// built. `version` says UNSIGNED for exactly that reason: a consumer must not be
+// able to mistake this for the attested article, and a later signed format must
+// not be satisfiable by downgrading to this one.
+//
+// What it does carry is everything checkable without a key: which rules judged
+// the decision, how they were applied, what the model proposed, and what was
+// actually sent. See docs/DECISION_RECEIPT.md §3.
+message DecisionReceipt {
+  // Format identifier. `AURA-RECEIPT-V0-UNSIGNED` today. The signed format gets
+  // its own name rather than a flag on this one.
+  string version = 1;
+
+  // Canonical digest of the decision the Transformer proposed, before the
+  // Membrane inspected it. Prose (`reasoning`, `message`, `thought`) is excluded
+  // — it is not decidable content, and hashing a model's free text would make
+  // the digest irreproducible.
+  string claim_hash = 2;
+
+  // The rule set that judged it: `guard/negotiation@1.0.0+<hex16>`. Empty when
+  // no rule set was consulted.
+  string ruleset_version = 3;
+
+  // How the verdict was reached. Absent when no declared gate ran.
+  DecisionDerivation derivation = 4;
+
+  // Canonical digest of what was actually emitted, over the same fields as
+  // claim_hash. The two differing IS the Membrane's intervention, stated as a
+  // fact a reader can check rather than a claim they must trust.
+  string emission_hash = 5;
+
+  // The Membrane's verdict, and the first gate that produced it.
+  DecisionOutcome outcome = 6;
+  string outcome_gate = 7;
+
+  // First eight bytes of SHA-256 over the content fields, as 16 lowercase hex.
+  // A human-legible handle for logs and UI — NOT a binding commitment. Nothing
+  // is bound until something signs it.
+  string canonical_prefix = 8;
+
+  // Reserved for the fields that need keys or a salt, so nothing reuses these
+  // numbers meanwhile. premise_hash (§3.1) needs the salt decision;
+  // policy_stamp (§3.5) needs the public/committed split; verifier (§3.7) needs
+  // a signing identity.
+  reserved 9, 10, 11;
+  reserved "premise_hash", "policy_stamp", "verifier";
+}
+
 message Intent {
   string identifier = 1;  // Schema.org compliant
   ActionType action = 2;
@@ -234,21 +286,15 @@ message Intent {
   google.protobuf.Struct metadata = 5;
   TraceContext trace = 6;
 
-  // Membrane verdict. Set at the outbound boundary, never by the Transformer.
-  DecisionOutcome outcome = 7;
+  // Folded into `receipt` below: outcome (7), outcome_gate (8) and
+  // derivation (9) lived here first and moved once there was a message to hold
+  // them together. Reserved so the numbers cannot be reused for anything else.
+  reserved 7, 8, 9;
+  reserved "outcome", "outcome_gate", "derivation";
 
-  // The invariant that fired, as the guard's own error code
-  // (FLOOR_PRICE_VIOLATION, DLP_BLOCK, KYC_FAILURE, ...). Empty when the
-  // outcome is EMIT.
-  //
-  // Records the FIRST gate that fired, not every gate that would have. A full
-  // set is an oracle over the policy configuration: probe with crafted offers,
-  // read back which invariants answered, and the shape of the hidden floor
-  // falls out. This constrains only what is recorded — every gate still runs.
-  string outcome_gate = 8;
-
-  // How the Membrane reached that verdict. Absent when no declared gate ran.
-  DecisionDerivation derivation = 9;
+  // What the Membrane attests about this decision. Set at the outbound
+  // boundary, never by the Transformer.
+  DecisionReceipt receipt = 16;
 
   // Strictly typed action params
   oneof params {


### PR DESCRIPTION
Step 6 of `docs/DECISION_RECEIPT.md` §6. Follows #255, #258, #260.

## What

Three steps each added a field to `Intent` — `outcome`, `outcome_gate`, `derivation`. `DecisionReceipt` gathers them; `Intent` reserves 7, 8 and 9 so the numbers cannot be reused.

The addition that earns the message is the **claim/emission pair**:

| outcome | `claim_hash` vs `emission_hash` |
|---|---|
| `EMIT` | equal |
| `OVERRIDE` | differ |

`claim_hash` digests what the Transformer proposed, `emission_hash` what is actually sent, over the same canonical form. The two differing **is** the override — a fact a reader checks by comparing two hex strings, rather than a claim they take on trust from a field the same party filled in.

Prose is excluded from that form. `reasoning`, `message` and `thought` are the model's free text; they are not what the decision decides, and hashing them would make the digest irreproducible for anyone who did not receive the byte-exact string. The price renders to fixed precision, because `105.0` and `105.000000001` must be one claim and arithmetic hands you the second.

## This is not a receipt yet, and it says so

VISION §5.1.7 is explicit that a receipt without a valid verifier signature is not a receipt regardless of any other field. The signature (§3.7) and premise hash (§3.1) are not built, so:

- the version reads **`AURA-RECEIPT-V0-UNSIGNED`** — the signed format will take its own name rather than flipping a flag, so a consumer written against it cannot be satisfied by a downgrade;
- `verify` **refuses an unrecognised version outright** instead of best-effort checking. A future signed receipt read by this code would have its signature ignored, and answering `ok` on it is the downgrade the version string exists to prevent;
- `verify` **names what it could not check** (`signature`, `premises`, `policy`). A verifier that answers "valid" while silently skipping the integrity check teaches its consumer to rely on a guarantee nobody made;
- `attested` is a separate field from `ok`, so "nothing was wrong" cannot read as "someone vouched for this".

The proto reserves 9/10/11 for `premise_hash`, `policy_stamp` and `verifier`.

## Notes for review

- **The verdict is accumulated then minted once**, in a `_Verdict`, rather than written onto the `Intent` as the path proceeds. The Intent on the override path is replaced part-way, and a verdict half-written onto a discarded object is exactly how `outcome_gate` nearly lost its first gate in #255.
- **Existing tests migrated** from `decision.outcome` to `decision.receipt.outcome` etc. Mechanical, but worth a glance that nothing lost its meaning.
- `_replacing()` no longer carries `outcome_gate`/`derivation` — the receipt is minted on the emission from the verdict, so there is nothing to carry.

## Two limits, recorded rather than left to be discovered

- **A prose-only override shows equal hashes.** DLP rewrites the message and nothing else, and prose is outside the claim. Bringing prose in would cost determinism on every decision to catch this one case, so `verify` reads the gate instead: an override under a *non*-prose gate whose hashes agree is a receipt describing something that did not happen, and is reported as a failure.
- **Refusals carry no derivation.** VISION §5.1.4 wants a real digest there. Ours are Membrane-level checks (KYC, trade risk) that no rule set declares, so there are no gate ids to record. Honest, but a gap against the spec.

## The bee-keeper half was mis-specified and is not built

Step 6 as written said "bee-keeper verifies receipts in CI audit". That does not work: **bee.Keeper audits architecture** — it reads the codebase through an LLM and the VCS protein and never sees an emitted `Intent`. There are no persisted receipts in CI for it to verify.

Receipt checking is a library function (`verify`) exercised by tests instead. Wiring it into a real audit needs decisions persisted somewhere an auditor can read, which is its own piece of work and not obviously worth doing before receipts are signed. Recorded in §6.

## Testing

```
core/tests/test_receipt.py               24 passed  (new)
core/tests/                             359 passed  (was 328)
api-gateway / telegram-bot / bee-keeper    1 / 6 / 7 passed
ruff check + format                        clean
mypy core/src                              86 files, no issues
buf lint                                   clean
tools/check_fractal_completeness.py        OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)