### PR TITLE
feat(membrane): sign the receipt, under a domain of its own

### DIFF
--- a/core/src/aura_hive/hive/membrane/main.py
+++ b/core/src/aura_hive/hive/membrane/main.py
@@ -201,7 +201,7 @@ def _outcome_label(outcome: Any) -> str:
     """`override`, not `2` — the log line is read by people."""
     try:
         name = DecisionOutcome(int(outcome)).name or ""
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, AttributeError):
         return f"outcome_{outcome}"
     return name.removeprefix("DECISION_OUTCOME_").lower()
 
@@ -211,8 +211,8 @@ def _action_label(action: Any) -> str:
     try:
         name = ActionType(int(action)).name
         return name.lower() if name else f"action_{int(action)}"
-    except (ValueError, AttributeError):
-        return f"action_{int(action)}"
+    except (ValueError, TypeError, AttributeError):
+        return f"action_{action}"
 
 
 class HiveMembrane(Membrane[Any, Intent, Context]):
@@ -237,14 +237,23 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
         """
         receipt = _mint_for(claim, emission, verdict)
         emission.receipt = await self._attest(receipt)
-        logger.info(
-            "membrane_receipt",
-            prefix=emission.receipt.canonical_prefix,
-            outcome=_outcome_label(emission.receipt.outcome),
-            gate=emission.receipt.outcome_gate or None,
-            ruleset=emission.receipt.ruleset_version or None,
-            attested=bool(emission.receipt.signature),
-        )
+
+        try:
+            logger.info(
+                "membrane_receipt",
+                prefix=emission.receipt.canonical_prefix,
+                outcome=_outcome_label(emission.receipt.outcome),
+                gate=emission.receipt.outcome_gate or None,
+                ruleset=emission.receipt.ruleset_version or None,
+                attested=bool(emission.receipt.signature),
+            )
+        except Exception as e:  # nosec B110
+            # The same rule `_record_intervention` follows, and for the same
+            # reason: reporting on a decision must never take that decision
+            # down. Losing a negotiation over a sentence nobody was going to
+            # read at the time is the worst trade in the file.
+            logger.error("membrane_receipt_log_failed", error=str(e))
+
         return emission
 
     async def _attest(self, receipt: DecisionReceipt) -> DecisionReceipt:
@@ -253,12 +262,14 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
             return receipt
 
         try:
-            # Reading the chain id sits inside the try with everything else.
-            # It cannot raise today — `Settings.crypto` is a pydantic field with
-            # a default factory, so it is never absent — but a promise that
-            # nothing here costs the decision should hold because of where the
-            # code sits, not because someone checked each line and found it safe.
-            chain_id = int(getattr(self.settings.crypto, "evm_chain_id", 0) or 0)
+            # Looked up rather than accessed: settings with no crypto section
+            # is a configuration a deployment may legitimately have, and an
+            # expected absence should not be discovered by throwing. The try
+            # still wraps it, because the promise that nothing here costs the
+            # decision should hold from where the code sits rather than from
+            # someone having checked each line.
+            crypto = getattr(self.settings, "crypto", None)
+            chain_id = int(getattr(crypto, "evm_chain_id", 0) or 0)
             obs = await self.registry.execute(
                 "transaction",
                 "sign_receipt",

--- a/core/src/aura_hive/hive/membrane/main.py
+++ b/core/src/aura_hive/hive/membrane/main.py
@@ -252,16 +252,21 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
         if not self.registry:
             return receipt
 
-        chain_id = int(getattr(self.settings.crypto, "evm_chain_id", 0) or 0)
         try:
+            # Reading the chain id sits inside the try with everything else.
+            # It cannot raise today — `Settings.crypto` is a pydantic field with
+            # a default factory, so it is never absent — but a promise that
+            # nothing here costs the decision should hold because of where the
+            # code sits, not because someone checked each line and found it safe.
+            chain_id = int(getattr(self.settings.crypto, "evm_chain_id", 0) or 0)
             obs = await self.registry.execute(
                 "transaction",
                 "sign_receipt",
                 {"payload": signing_payload(receipt, chain_id=chain_id)},
             )
         except Exception as e:
-            # Inside the try for the same reason the metric counter is: an
-            # attestation failure must not take down the decision it describes.
+            # Caught for the same reason the metric counter is: an attestation
+            # failure must not take down the decision it describes.
             logger.warning("membrane_receipt_unsigned", error=str(e))
             return receipt
 

--- a/core/src/aura_hive/hive/membrane/main.py
+++ b/core/src/aura_hive/hive/membrane/main.py
@@ -9,6 +9,7 @@ from aura_core_gen.aura.core.v1 import (
     Context,
     DecisionDerivation,
     DecisionOutcome,
+    DecisionReceipt,
     Intent,
     NegotiationIntent,
     RWAVaultIntent,
@@ -18,7 +19,7 @@ from prometheus_client import REGISTRY, Counter
 
 from aura_hive.config import get_settings
 
-from .receipt import mint
+from .receipt import mint, signed, signing_payload
 
 logger = structlog.get_logger(__name__)
 
@@ -134,15 +135,13 @@ class _Verdict:
             )
 
 
-def _finish(claim: Intent, emission: Intent, verdict: _Verdict) -> Intent:
+def _mint_for(claim: Intent, emission: Intent, verdict: _Verdict) -> DecisionReceipt:
     """
-    Attach the receipt and hand back the Intent that will actually be sent.
-
     `claim` is what the Transformer proposed and `emission` is what is going
     out; they are the same object when the Membrane changed nothing, and the two
     hashes agreeing is then a fact a reader can check rather than an assumption.
     """
-    emission.receipt = mint(
+    return mint(
         claim=claim,
         emission=emission,
         outcome=verdict.outcome,
@@ -150,7 +149,6 @@ def _finish(claim: Intent, emission: Intent, verdict: _Verdict) -> Intent:
         ruleset_version=verdict.ruleset_version,
         derivation=verdict.derivation,
     )
-    return emission
 
 
 def _replacing(original: Intent, replacement: Intent) -> Intent:
@@ -199,6 +197,15 @@ def _context_number(ctx_meta: dict[str, Any], key: str, default: float) -> float
         return default
 
 
+def _outcome_label(outcome: Any) -> str:
+    """`override`, not `2` — the log line is read by people."""
+    try:
+        name = DecisionOutcome(int(outcome)).name or ""
+    except (ValueError, TypeError):
+        return f"outcome_{outcome}"
+    return name.removeprefix("DECISION_OUTCOME_").lower()
+
+
 def _action_label(action: Any) -> str:
     """Safely convert ActionType or raw int to a lowercase name string."""
     try:
@@ -214,6 +221,62 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
     def __init__(self, registry: SkillRegistry | None = None) -> None:
         self.settings = get_settings()
         self.registry = registry
+
+    async def _finish(
+        self, claim: Intent, emission: Intent, verdict: _Verdict
+    ) -> Intent:
+        """
+        Attach the receipt to the Intent that will actually be sent, asking
+        whoever holds the key to attest it.
+
+        A receipt that cannot be signed is still emitted, unsigned. The decision
+        it accompanies has already been made and is already safe by this point,
+        so losing it because a key was unreachable would trade the guarantee for
+        the attestation — the wrong way round. The version name carries that
+        distinction rather than leaving a reader to infer it.
+        """
+        receipt = _mint_for(claim, emission, verdict)
+        emission.receipt = await self._attest(receipt)
+        logger.info(
+            "membrane_receipt",
+            prefix=emission.receipt.canonical_prefix,
+            outcome=_outcome_label(emission.receipt.outcome),
+            gate=emission.receipt.outcome_gate or None,
+            ruleset=emission.receipt.ruleset_version or None,
+            attested=bool(emission.receipt.signature),
+        )
+        return emission
+
+    async def _attest(self, receipt: DecisionReceipt) -> DecisionReceipt:
+        """Ask the protein that holds the key to sign, or return it unsigned."""
+        if not self.registry:
+            return receipt
+
+        chain_id = int(getattr(self.settings.crypto, "evm_chain_id", 0) or 0)
+        try:
+            obs = await self.registry.execute(
+                "transaction",
+                "sign_receipt",
+                {"payload": signing_payload(receipt, chain_id=chain_id)},
+            )
+        except Exception as e:
+            # Inside the try for the same reason the metric counter is: an
+            # attestation failure must not take down the decision it describes.
+            logger.warning("membrane_receipt_unsigned", error=str(e))
+            return receipt
+
+        if not obs.success:
+            logger.warning("membrane_receipt_unsigned", error=obs.error)
+            return receipt
+
+        meta = obs.metadata.to_dict() if obs.metadata is not None else {}
+        signer = str(meta.get("signer") or "")
+        signature = str(meta.get("signature") or "")
+        if not signer or not signature:
+            logger.warning("membrane_receipt_unsigned", error="signer reported neither")
+            return receipt
+
+        return signed(receipt, signer=signer, signature=signature, chain_id=chain_id)
 
     async def inspect_inbound(self, signal: Any) -> Any:
         from aura_core_gen.aura.core.v1 import Signal
@@ -325,7 +388,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                     wallet_address=rwa_intent.wallet_address,
                 )
                 verdict.record(_REFUSE, "KYC_FAILURE")
-                return _finish(
+                return await self._finish(
                     decision,
                     _replacing(
                         decision,
@@ -338,7 +401,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                     ),
                     verdict,
                 )
-            return _finish(decision, decision, verdict)
+            return await self._finish(decision, decision, verdict)
 
         # Trade intent guard: backstop for high-risk trades that slipped through
         if params_name == "trade" and params_value is not None:
@@ -353,7 +416,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                     risk_category=trade_intent.validation_score.risk_category,
                 )
                 verdict.record(_REFUSE, "HIGH_RISK_TRADE")
-                return _finish(
+                return await self._finish(
                     decision,
                     _replacing(
                         decision,
@@ -366,7 +429,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                     ),
                     verdict,
                 )
-            return _finish(decision, decision, verdict)
+            return await self._finish(decision, decision, verdict)
 
         neg_intent = params_value if params_name == "negotiation" else None
 
@@ -387,7 +450,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                         str(obs_safe.metadata.to_dict().get("safe_price", safe_price))
                     )
 
-            return self._override_with_safe_offer(
+            return await self._override_with_safe_offer(
                 decision, safe_price, "FAILURE_RECOVERY", verdict
             )
 
@@ -404,11 +467,11 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
             ActionType.ACTION_TYPE_ACCEPT,
             ActionType.ACTION_TYPE_COUNTER,
         ]:
-            return _finish(decision, decision, verdict)
+            return await self._finish(decision, decision, verdict)
 
         # 3. Call Guard Protein for validation
         if not self.registry:
-            return _finish(decision, decision, verdict)
+            return await self._finish(decision, decision, verdict)
 
         internal_cost = _context_number(ctx_meta, "internal_cost", floor_price)
         guard_context = {"floor_price": floor_price, "internal_cost": internal_cost}
@@ -449,11 +512,13 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
             reason = str(obs_meta.get("error_code", "SAFETY_VIOLATION"))
             safe_price = float(str(obs_meta.get("safe_price", safe_price)))
 
-            return self._override_with_safe_offer(decision, safe_price, reason, verdict)
+            return await self._override_with_safe_offer(
+                decision, safe_price, reason, verdict
+            )
 
-        return _finish(decision, decision, verdict)
+        return await self._finish(decision, decision, verdict)
 
-    def _override_with_safe_offer(
+    async def _override_with_safe_offer(
         self, original: Intent, safe_price: float, reason: str, verdict: _Verdict
     ) -> Intent:
         _record_intervention("outbound", reason, safe_price=round(safe_price, 2))
@@ -481,4 +546,4 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
             ),
         )
         verdict.record(_OVERRIDE, reason)
-        return _finish(original, _replacing(original, replacement), verdict)
+        return await self._finish(original, _replacing(original, replacement), verdict)

--- a/core/src/aura_hive/hive/membrane/receipt.py
+++ b/core/src/aura_hive/hive/membrane/receipt.py
@@ -1,22 +1,28 @@
 """
 Mints and checks what the Membrane can attest about a decision.
 
-This is not a receipt in the sense VISION means. §5.1.7 holds that a receipt
-without a valid verifier signature is not a receipt regardless of any other
-field, and neither the signature (§3.7) nor the premise hash (§3.1) is built —
-both wait on decisions this code cannot make for itself: who holds the salt, and
-what key signs.
+Two formats, and the difference is the point. `AURA-RECEIPT-V1` carries an
+EIP-712 signature over its content fields and can be attributed to the agent
+that produced it. `AURA-RECEIPT-V0-UNSIGNED` carries everything else and says in
+its own name that it carries no attestation, which is what a deployment with no
+key configured honestly produces.
 
-So the format calls itself UNSIGNED and `verify` reports what it could not
-check. A verifier that answers "valid" while silently skipping the integrity
-check is worse than no verifier: it teaches its consumer to rely on a guarantee
-nobody made.
+They are separate names rather than one name and a flag, so a consumer written
+against the signed format cannot be satisfied by a downgrade, and `verify`
+refuses a version it does not recognise instead of best-effort checking one.
+
+`verify` also reports what it could not check. The premise hash (§3.1) is still
+unbuilt — and on our premises it can only ever be a commitment opened to a
+trusted party, never a counterparty-verifiable field, because they are
+low-entropy enough that anyone holding the salt can recover them. A verifier
+answering "valid" while silently skipping a check teaches its consumer to rely
+on a guarantee nobody made.
 
 See docs/DECISION_RECEIPT.md §3 for the field-by-field design.
 """
 
 import hashlib
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 import betterproto
@@ -28,13 +34,30 @@ from aura_core_gen.aura.core.v1 import (
     DecisionReceipt,
     Intent,
     NegotiationIntent,
+    ReceiptSignature,
     RWAVaultIntent,
     TradeIntent,
 )
+from eth_account import Account
+from eth_account.messages import encode_typed_data
 
-# The signed format will take its own name rather than flipping a flag on this
-# one, so that a consumer written against it cannot be satisfied by a downgrade.
+# The signed format takes its own name rather than flipping a flag on the
+# unsigned one, so a consumer written against it cannot be satisfied by a
+# downgrade. A deployment with no key configured produces the unsigned format
+# and says so — that is the honest report, not an error.
 RECEIPT_VERSION = "AURA-RECEIPT-V0-UNSIGNED"
+SIGNED_VERSION = "AURA-RECEIPT-V1"
+
+# Kept DISTINCT from the domain TradeIntent signs under (`HackathonRiskRouter`).
+#
+# This is the whole reason reusing the agent's spending key is acceptable: with
+# separate domain separators a receipt signature is not a valid trade
+# authorisation and a trade authorisation is not a valid receipt. `signing_payload`
+# also omits `verifyingContract` — a receipt has no contract — which makes the
+# domain structurally different rather than merely differently named.
+RECEIPT_EIP712_DOMAIN = "AuraDecisionReceipt"
+RECEIPT_EIP712_VERSION = "1"
+_SIGNATURE_SCHEME = "eip712"
 
 # Width of the human-legible handle, in hex characters. Enough to be distinctive
 # in a log line, and not a commitment — nothing is bound until something signs.
@@ -221,6 +244,90 @@ def mint(
     return receipt
 
 
+def signing_payload(receipt: DecisionReceipt, chain_id: int) -> dict[str, Any]:
+    """
+    EIP-712 structured data for a receipt, as it will read once signed.
+
+    Computed against the signed form's content fields — `version` is one of
+    them, so signing the unsigned form would produce an attestation over a
+    document that no longer exists the moment the version is bumped.
+    """
+    probe = replace(receipt, version=SIGNED_VERSION)
+    return {
+        "types": {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+            ],
+            "DecisionReceipt": [{"name": "content", "type": "string"}],
+        },
+        "domain": {
+            "name": RECEIPT_EIP712_DOMAIN,
+            "version": RECEIPT_EIP712_VERSION,
+            "chainId": chain_id,
+        },
+        "primaryType": "DecisionReceipt",
+        "message": {"content": _content_fields(probe)},
+    }
+
+
+def signed(
+    receipt: DecisionReceipt, signer: str, signature: str, chain_id: int
+) -> DecisionReceipt:
+    """
+    A copy of the receipt bearing the attestation, at the signed version.
+
+    Returns a new receipt rather than mutating: the version and the prefix both
+    change, and a half-updated receipt in a caller's hand is a document that
+    verifies as neither format.
+    """
+    attested = replace(
+        receipt,
+        version=SIGNED_VERSION,
+        signature=ReceiptSignature(
+            scheme=_SIGNATURE_SCHEME,
+            domain=RECEIPT_EIP712_DOMAIN,
+            domain_version=RECEIPT_EIP712_VERSION,
+            chain_id=chain_id,
+            signer=signer,
+            signature=signature if signature.startswith("0x") else f"0x{signature}",
+        ),
+    )
+    attested.canonical_prefix = _prefix(attested)
+    return attested
+
+
+def _check_signature(receipt: DecisionReceipt) -> list[str]:
+    """
+    Recover the signer from the attestation and confirm it is who is claimed.
+
+    Needs no key material — verification is public by construction, which is
+    why it lives here rather than behind the protein that holds the private
+    key. The domain is rebuilt from the receipt's own fields, so a reader needs
+    no out-of-band configuration.
+    """
+    signature = receipt.signature
+    if signature is None or not signature.signature:
+        return ["receipt claims the signed format but carries no signature"]
+
+    payload = signing_payload(receipt, chain_id=signature.chain_id)
+    try:
+        recovered = Account.recover_message(
+            encode_typed_data(full_message=payload), signature=signature.signature
+        )
+    except Exception as exc:
+        return [f"signature could not be recovered: {exc}"]
+
+    if recovered.lower() != signature.signer.lower():
+        return [
+            f"signature recovers to {recovered}, not the signer "
+            f"{signature.signer} the receipt claims"
+        ]
+
+    return []
+
+
 def verify(receipt: DecisionReceipt) -> VerificationResult:
     """
     Re-derive everything checkable without a key, and say what was skipped.
@@ -230,16 +337,17 @@ def verify(receipt: DecisionReceipt) -> VerificationResult:
     signature ignored, and answering `ok` on it is exactly the downgrade the
     version string exists to prevent.
     """
-    if receipt.version != RECEIPT_VERSION:
+    if receipt.version not in (RECEIPT_VERSION, SIGNED_VERSION):
         return VerificationResult(
             ok=False,
             failures=(
                 f"unknown receipt version {receipt.version!r}; "
-                f"this verifier only reads {RECEIPT_VERSION}",
+                f"this verifier reads {RECEIPT_VERSION} and {SIGNED_VERSION}",
             ),
         )
 
-    failures: list[str] = []
+    attested = receipt.version == SIGNED_VERSION
+    failures: list[str] = _check_signature(receipt) if attested else []
 
     if receipt.canonical_prefix != _prefix(receipt):
         failures.append("canonical prefix does not match the content fields")
@@ -271,11 +379,20 @@ def verify(receipt: DecisionReceipt) -> VerificationResult:
     if receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT and changed:
         failures.append("emit recorded but the emission does not match the claim")
 
+    # Named rather than counted, so a caller reads what is missing instead of a
+    # number they have to look up. The premise hash and the policy stamp are
+    # still unbuilt, so they stay listed even on a signed receipt: a signature
+    # attests to what the receipt says, not to everything a reader might want.
+    unverifiable = ["premises", "policy"]
+    if not attested:
+        unverifiable.insert(0, "signature")
+
     return VerificationResult(
         ok=not failures,
         failures=tuple(failures),
-        # Named rather than counted, so a caller reads what is missing instead
-        # of a number they have to look up.
-        unverifiable=("signature", "premises", "policy"),
-        attested=False,
+        unverifiable=tuple(unverifiable),
+        # Only when a signature was present AND recovered to the claimed signer.
+        # A failed check leaves this False rather than True-with-failures, so a
+        # caller reading one field cannot get the wrong answer.
+        attested=attested and not failures,
     )

--- a/core/src/aura_hive/hive/proteins/transaction/engine.py
+++ b/core/src/aura_hive/hive/proteins/transaction/engine.py
@@ -200,6 +200,28 @@ class EVMProvider:
             "structured_data": structured_data,
         }
 
+    async def sign_receipt(self, payload: dict[str, Any]) -> dict[str, str]:
+        """
+        Sign an EIP-712 payload the Membrane built for a decision receipt.
+
+        The payload arrives fully formed rather than being assembled here: the
+        Membrane owns what a receipt says, this protein owns the key, and having
+        one build a document the other signs blind is how the two drift into
+        signing different things.
+
+        Domain separation is what makes reusing the agent's spending key
+        acceptable — the receipt domain is not `HackathonRiskRouter`, so a
+        receipt signature is not a valid trade authorisation and vice versa.
+        That property lives in the payload, so this method must not second-guess
+        the domain it was handed.
+        """
+        signed_msg = encode_typed_data(full_message=payload)
+        signature = self.account.sign_message(signed_msg)
+        return {
+            "signer": self.account.address,
+            "signature": signature.signature.hex(),
+        }
+
     async def close(self) -> None:
         # AsyncWeb3 doesn't strictly need close for HTTP provider, but good practice
         pass

--- a/core/src/aura_hive/hive/proteins/transaction/skill.py
+++ b/core/src/aura_hive/hive/proteins/transaction/skill.py
@@ -48,6 +48,7 @@ class TransactionSkill(
             "get_network_name": self._get_network_name,
             "transfer": self._transfer,
             "sign_trade_intent": self._sign_trade_intent,
+            "sign_receipt": self._sign_receipt,
             "submit_to_router": self._submit_to_router,
             "execute_rwa_collateral": self._execute_rwa_collateral,
             "mint_rwa_vault": self._mint_rwa_vault,
@@ -212,6 +213,29 @@ class TransactionSkill(
             )
         except Exception as e:
             logger.error(f"EIP-712 signing failed: {e}")
+            return Observation(success=False, error=str(e))
+
+    async def _sign_receipt(self, params: dict[str, Any]) -> Observation:
+        """
+        Attest a decision receipt the Membrane built.
+
+        Failure is reported rather than raised. The decision this receipt
+        describes has already been made and is already safe; the Membrane keeps
+        the unsigned receipt and emits anyway, because losing a negotiation
+        because a key was unreachable trades the guarantee for the attestation.
+        """
+        payload = params.get("payload")
+        if not payload:
+            return Observation(success=False, error="payload_missing")
+
+        if not self.evm_provider:
+            return Observation(success=False, error="evm_provider_not_configured")
+
+        try:
+            result = await self.evm_provider.sign_receipt(payload)
+            return Observation(success=True, metadata=make_struct(result))
+        except Exception as e:
+            logger.error(f"Receipt signing failed: {e}")
             return Observation(success=False, error=str(e))
 
     async def _submit_to_router(self, params: dict[str, Any]) -> Observation:

--- a/core/tests/test_membrane_derivation.py
+++ b/core/tests/test_membrane_derivation.py
@@ -12,6 +12,8 @@ Nothing here is worth having if the record leaks a number, so that is asserted
 against the Intent itself rather than only against the engine that built it.
 """
 
+from unittest.mock import patch
+
 import pytest
 from aura_core import SkillRegistry
 from aura_core.struct_utils import make_struct
@@ -631,3 +633,25 @@ class TestNothingInAttestationCanCostTheDecision:
 
         assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
         assert decision.negotiation.price != 500.0
+
+    @pytest.mark.asyncio
+    async def test_a_broken_logger_does_not_cost_the_decision(self) -> None:
+        """
+        The same rule `_record_intervention` already follows, applied to the
+        receipt log line: reporting on a decision must never take that decision
+        down. A log call that raises would lose the negotiation for a sentence
+        nobody was going to read at the time.
+        """
+        membrane = guarded_membrane()
+
+        with patch(
+            "aura_hive.hive.membrane.main.logger.info",
+            side_effect=RuntimeError("log sink is gone"),
+        ):
+            decision = await membrane.inspect_outbound(
+                counter_intent(price=500.0), negotiation_context()
+            )
+
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
+        assert decision.negotiation.price != 500.0
+        assert decision.receipt.canonical_prefix != ""

--- a/core/tests/test_membrane_derivation.py
+++ b/core/tests/test_membrane_derivation.py
@@ -31,6 +31,8 @@ from aura_hive.hive.membrane.main import HiveMembrane
 from aura_hive.hive.membrane.receipt import verify
 from aura_hive.hive.proteins.guard import GuardSkill
 from aura_hive.hive.proteins.guard.engine import OutputGuard
+from eth_account import Account
+from eth_account.messages import encode_typed_data
 
 FLOOR = 1000.0
 
@@ -497,3 +499,104 @@ class TestAContextWithNullNumbers:
         )
 
         assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_EMIT
+
+
+class TestSigningTheReceipt:
+    """
+    The Membrane asks whoever holds the key to attest the receipt it just
+    minted. Everything here is about what happens when that does not work.
+    """
+
+    class _Signer:
+        """Stands in for the transaction protein, which owns the EVM key."""
+
+        def __init__(self, account: object | None = None, fail: bool = False) -> None:
+            self.account = account
+            self.fail = fail
+
+        def get_name(self) -> str:
+            return "transaction"
+
+        async def execute(self, intent: str, params: dict) -> Observation:
+            if self.fail:
+                raise RuntimeError("hardware wallet unplugged")
+            payload = params["payload"]
+            sig = self.account.sign_message(encode_typed_data(full_message=payload))
+            return Observation(
+                success=True,
+                metadata=make_struct(
+                    {"signer": self.account.address, "signature": sig.signature.hex()}
+                ),
+            )
+
+    def membrane_with(self, signer: object | None) -> HiveMembrane:
+        registry = SkillRegistry()
+        guard = GuardSkill()
+        guard.bind(_Safety(), OutputGuard(safety_settings=_Safety()))
+        registry.register(guard.get_name(), guard)
+        if signer is not None:
+            registry.register(signer.get_name(), signer)
+        return HiveMembrane(registry=registry)
+
+    @pytest.mark.asyncio
+    async def test_a_signed_receipt_verifies_and_is_attested(self) -> None:
+        account = Account.create()
+        membrane = self.membrane_with(self._Signer(account))
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=500.0), negotiation_context()
+        )
+
+        result = verify(decision.receipt)
+        assert result.ok, result.failures
+        assert result.attested
+        assert decision.receipt.signature.signer == account.address
+
+    @pytest.mark.asyncio
+    async def test_no_signer_means_an_unsigned_receipt_that_says_so(self) -> None:
+        """
+        Not an error. A deployment with no key still produces a usable record;
+        it just cannot be attributed, and the version name is where that is
+        stated rather than left for the reader to infer.
+        """
+        decision = await self.membrane_with(None).inspect_outbound(
+            counter_intent(price=500.0), negotiation_context()
+        )
+
+        result = verify(decision.receipt)
+        assert result.ok
+        assert not result.attested
+        assert "UNSIGNED" in decision.receipt.version
+
+    @pytest.mark.asyncio
+    async def test_a_failing_signer_does_not_cost_the_decision(self) -> None:
+        """
+        The decision has already been made and is safe by the time signing is
+        attempted. Losing it because a key was unreachable would trade the
+        guarantee for the attestation, which is the wrong way round.
+        """
+        membrane = self.membrane_with(self._Signer(fail=True))
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=500.0), negotiation_context()
+        )
+
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
+        assert decision.negotiation.price != 500.0
+        assert "UNSIGNED" in decision.receipt.version
+
+    @pytest.mark.asyncio
+    async def test_signing_covers_the_emitted_price_not_the_proposed_one(self) -> None:
+        """
+        The attestation has to be over what was sent. Signing the model's
+        proposal would attest to a document the counterparty never received.
+        """
+        account = Account.create()
+        membrane = self.membrane_with(self._Signer(account))
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=500.0), negotiation_context()
+        )
+
+        assert verify(decision.receipt).attested
+        assert decision.receipt.claim_hash != decision.receipt.emission_hash

--- a/core/tests/test_membrane_derivation.py
+++ b/core/tests/test_membrane_derivation.py
@@ -600,3 +600,34 @@ class TestSigningTheReceipt:
 
         assert verify(decision.receipt).attested
         assert decision.receipt.claim_hash != decision.receipt.emission_hash
+
+
+class TestNothingInAttestationCanCostTheDecision:
+    """
+    `_attest` promises that a decision survives any failure to sign it. That
+    promise should hold structurally, not because someone audited each line.
+
+    The chain id was read outside the try block. It could not actually raise —
+    `Settings.crypto` is a pydantic field with a default factory, so it is never
+    absent, and `getattr(None, ..., 0)` returns the default rather than raising.
+    But a property that holds only under analysis stops holding the moment
+    someone edits the line, and there is nothing to catch that.
+    """
+
+    @pytest.mark.asyncio
+    async def test_settings_without_crypto_still_emit_the_decision(self) -> None:
+        membrane = guarded_membrane()
+
+        class _NoCrypto:
+            """Settings as a stub might supply them: no crypto section at all."""
+
+            safety = _Safety()
+
+        membrane.settings = _NoCrypto()
+
+        decision = await membrane.inspect_outbound(
+            counter_intent(price=500.0), negotiation_context()
+        )
+
+        assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
+        assert decision.negotiation.price != 500.0

--- a/core/tests/test_receipt.py
+++ b/core/tests/test_receipt.py
@@ -8,11 +8,15 @@ model proposed and a digest of what was actually sent. Those two differing IS
 the override, stated as a fact a reader can verify rather than a claim they must
 take on trust.
 
-It is deliberately not called a receipt in the spec's sense. VISION §5.1.7 holds
-that an unsigned receipt is not a receipt regardless of any other field, and
-neither the signature nor the premise hash exists yet. The format identifier says
-UNSIGNED so nothing can mistake this for the attested article, and `verify` is
-explicit about which checks it did not perform.
+There are two formats. `AURA-RECEIPT-V1` carries an EIP-712 signature and can be
+attributed to the agent that produced it; `AURA-RECEIPT-V0-UNSIGNED` carries
+everything else and says in its own name that it carries no attestation. Separate
+names rather than one name and a flag, so a consumer written against the signed
+format cannot be satisfied by a downgrade.
+
+`verify` stays explicit about what it did not check — the premise hash is still
+unbuilt, and a signature attests to what the receipt says rather than to
+everything a reader might want.
 """
 
 import hashlib
@@ -29,13 +33,20 @@ from aura_core_gen.aura.core.v1 import (
     TradeIntent,
 )
 from aura_hive.hive.membrane.receipt import (
+    RECEIPT_EIP712_DOMAIN,
     RECEIPT_VERSION,
+    SIGNED_VERSION,
     _prefix,
     canonical_claim,
     claim_digest,
     mint,
+    signed,
+    signing_payload,
     verify,
 )
+from aura_hive.hive.proteins.transaction.engine import EIP712_DOMAIN_NAME
+from eth_account import Account
+from eth_account.messages import encode_typed_data
 
 
 def counter(price: float, item: str = "htl-9931", message: str = "an offer") -> Intent:
@@ -429,7 +440,7 @@ class TestVerifyIsHonestAboutWhatItCannotCheck:
         the downgrade the version string exists to prevent.
         """
         receipt = self.base_receipt()
-        receipt.version = "AURA-RECEIPT-V1"
+        receipt.version = "AURA-RECEIPT-V9-WITH-SOMETHING-NEW"
 
         result = verify(receipt)
 
@@ -483,3 +494,128 @@ class TestTheAssetClaimAlsoNamesItsDecision:
         assert canonical_claim(intent) == (
             "action=approve;params=asset;asset=a-1;domain=lodging;asset_action=accept"
         )
+
+
+class TestSigning:
+    """
+    A signature is what turns this from a record into an attestation.
+
+    It is signed with the same EVM key the agent already uses on-chain, under a
+    domain of its own. Not for convenience: a signature under a key nobody can
+    attribute is decoration, and key distribution is the hard part. The EVM
+    identity already has an answer — a counterparty resolves the recovered
+    address against the ERC-8004 registry — where a fresh signing key would have
+    none.
+    """
+
+    def receipt(self) -> object:
+        return mint(
+            claim=counter(price=92.0),
+            emission=counter(price=105.0),
+            ruleset_version="guard/negotiation@1.0.0+46cc0e38ca4f895c",
+            outcome=DecisionOutcome.DECISION_OUTCOME_OVERRIDE,
+            outcome_gate="FLOOR_PRICE_VIOLATION",
+        )
+
+    def sign_with(self, receipt: object, account: object) -> object:
+        payload = signing_payload(receipt, chain_id=84532)
+        signature = account.sign_message(encode_typed_data(full_message=payload))
+        return signed(
+            receipt,
+            signer=account.address,
+            signature=signature.signature.hex(),
+            chain_id=84532,
+        )
+
+    def test_the_domain_is_not_the_one_trades_are_signed_under(self) -> None:
+        """
+        The whole reason reusing the spending key is acceptable. Different
+        domain separator means a receipt signature cannot be replayed as a trade
+        authorisation, nor a trade authorisation as a receipt.
+        """
+        payload = signing_payload(self.receipt(), chain_id=84532)
+
+        assert payload["domain"]["name"] == RECEIPT_EIP712_DOMAIN
+        assert payload["domain"]["name"] != EIP712_DOMAIN_NAME
+        # A receipt has no contract, so the field is absent rather than zeroed —
+        # which makes the domain structurally different, not merely renamed.
+        assert "verifyingContract" not in payload["domain"]
+
+    def test_signing_bumps_the_version_out_of_unsigned(self) -> None:
+        account = Account.create()
+
+        attested = self.sign_with(self.receipt(), account)
+
+        assert attested.version == SIGNED_VERSION
+        assert "UNSIGNED" not in attested.version
+        assert attested.signature.signer == account.address
+
+    def test_a_signed_receipt_verifies_and_is_attested(self) -> None:
+        account = Account.create()
+
+        result = verify(self.sign_with(self.receipt(), account))
+
+        assert result.ok, result.failures
+        assert result.attested
+        assert "signature" not in result.unverifiable
+
+    def test_an_unsigned_receipt_is_still_not_attested(self) -> None:
+        result = verify(self.receipt())
+
+        assert result.ok
+        assert not result.attested
+        assert "signature" in result.unverifiable
+
+    def test_a_tampered_content_field_breaks_the_signature(self) -> None:
+        """
+        The point of signing at all: altering what the receipt says must make it
+        stop verifying, not merely mismatch a prefix anyone could recompute.
+        """
+        account = Account.create()
+        attested = self.sign_with(self.receipt(), account)
+
+        attested.outcome_gate = "MIN_MARGIN_VIOLATION"
+        attested.canonical_prefix = _prefix(attested)  # a forger would fix this
+
+        result = verify(attested)
+
+        assert not result.ok
+        assert any("signature" in failure for failure in result.failures)
+
+    def test_a_signature_from_another_key_does_not_pass_as_ours(self) -> None:
+        """The recovered address is compared to the one the receipt claims."""
+        mine = Account.create()
+        theirs = Account.create()
+        attested = self.sign_with(self.receipt(), theirs)
+        attested.signature.signer = mine.address
+
+        result = verify(attested)
+
+        assert not result.ok
+        assert any("signer" in failure for failure in result.failures)
+
+    def test_a_signed_version_with_no_signature_is_refused(self) -> None:
+        """
+        Claiming the signed format while carrying nothing to check is the
+        downgrade the version string exists to prevent, arrived at from inside.
+        """
+        bare = self.receipt()
+        bare.version = SIGNED_VERSION
+        bare.canonical_prefix = _prefix(bare)
+
+        result = verify(bare)
+
+        assert not result.ok
+        assert any("signature" in failure for failure in result.failures)
+
+    def test_the_verifier_rebuilds_the_domain_from_the_receipt_alone(self) -> None:
+        """
+        No out-of-band configuration. A receipt only checkable by someone who
+        already knows how we are configured is not much of a receipt.
+        """
+        account = Account.create()
+        attested = self.sign_with(self.receipt(), account)
+
+        assert attested.signature.chain_id == 84532
+        assert attested.signature.domain == RECEIPT_EIP712_DOMAIN
+        assert verify(attested).ok

--- a/docs/DECISION_RECEIPT.md
+++ b/docs/DECISION_RECEIPT.md
@@ -1,8 +1,9 @@
 # Decision Receipt (AURA-RECEIPT-V1) — design sketch
 
-Status: **draft / not implemented**. Adapted from VISION whitepaper v1.7.0 (Durov, 2026-05-05),
-chapters 4–6. This document records where we follow that spec, and — more importantly — the three
-places where our domain forces us to diverge from it.
+Status: **steps 1, 2, 3, 5 and 6 built; step 4 deferred.** Adapted from VISION whitepaper v1.7.0
+(Durov, 2026-05-05), chapters 4–6. This document records where we follow that spec and — more
+importantly — the five places where our domain forces us to diverge from it. Sections marked
+*Implemented* describe code; the rest is still design.
 
 ## 1. What the receipt is for
 
@@ -29,9 +30,10 @@ verification boundary: it is the last deterministic checkpoint before `Connector
 signal → M(in) → A(perceive) → T(think) → M(out) ⇐ RECEIPT MINTED HERE → C(act) → G(pulse)
 ```
 
-The receipt attaches to `Intent.metadata` under key `receipt` (text form) so it survives the
-existing proto plumbing without a schema change on day one. A typed `DecisionReceipt` message in
-`aura/core/v1/metabolism.proto` is the follow-up once the format stabilises.
+The receipt is `Intent.receipt`, a typed `DecisionReceipt` in
+`aura/core/v1/metabolism.proto`. It is minted after the verdict is settled and signed by the
+transaction protein, which owns the key; a receipt that cannot be signed is emitted unsigned rather
+than costing the decision.
 
 ## 3. Wire format
 
@@ -65,16 +67,29 @@ canonical-prefix: <hex16>
 | `item` | `HiveContextData.item_identifier` | public |
 | `health` | `Context.system_health` | public |
 
-**The salt is mandatory, not optional.** VISION §8.7.1 treats salting as a per-domain option, but
-our premise set is low-entropy: `floor_price` is a two-decimal number over a bounded range, so an
-unsalted `premise-hash` is brute-forceable in ~10⁶ hashes. A deployment-scoped salt (rotated per
-epoch, its *commitment* published in the policy stamp) is required for the hidden-knowledge
-invariant to survive contact with the receipt. Without it, publishing receipts would defeat the DLP
-guard we already run in `inspect_outbound`.
+**Deferred — and the analysis changed what it would have to be.** The premise set is low-entropy:
+`floor_price` is a two-decimal number over a bounded range, ~10⁷ candidates on its own, ~10¹⁴ with
+`internal_cost` — hours on one GPU, and far less once you bound the range from the offers you have
+already seen.
 
-Consequence, accepted: receipts become verifiable only by parties holding the salt (us, an auditor
-under NDA, bee-keeper). The counterparty verifies everything *except* premise re-derivation. That is
-still strictly more than they can check today.
+So **anyone holding the salt can recover the premises by enumeration**. The salt is exactly as
+secret as `floor_price` itself, which means the premise hash can *never* be a counterparty-verifiable
+field: verification and secrecy are mutually exclusive here. It can only be a commitment we open to a
+party already trusted with the floor.
+
+That is a different threat from VISION's. §8.7.1 salts against **linkage** — "an adversary who
+observes a sequence of receipts may infer that two receipts consume the same premise set" — on
+premises assumed high-entropy, and records the salt *in the policy stamp*, where it is public. For
+our threat, inversion, their design accomplishes nothing.
+
+If built, the right primitive is a **per-receipt random nonce stored alongside the receipt**, not a
+configured salt: no long-lived secret to rotate, nothing whose leak retroactively exposes the whole
+history, and opening is selective — reveal `(nonce, premises)` for the one deal under dispute. Use
+HMAC rather than `SHA256(salt ‖ data)`; there is no reason to hand-roll a keyed digest.
+
+The prerequisite is not cryptographic: a commitment you cannot open is a random number, so this needs
+receipts persisted where an auditor can read them. **The question to answer before writing any of it
+is who opens it and when.** Without a concrete dispute or audit flow, this is ceremony.
 
 ### 3.2 `claim-hash`
 
@@ -261,15 +276,47 @@ Two limits worth stating rather than discovering later:
   trade risk) that no rule set declares, so there are no gate ids to record (§3.3). They carry an
   `outcome_gate` and an empty derivation, which is honest but is a gap against the spec.
 
-### 3.7 `verifier` and `canonical-prefix`
+### 3.7 `signature` and `canonical-prefix`
 
-Ed25519 over `canon(lines 2–9)`, signed with the agent's existing identity key — the same key
-already used for wallet sanctification, which binds receipts to our ERC-8004 identity work. The
-`verifier` value is `<agent-id>@<key-fingerprint-hex16>` followed by the 128-hex signature.
+**Implemented.** EIP-712 over the receipt's content fields, signed with the agent's existing
+**EVM key** — not the Ed25519 scheme this document first sketched.
 
-`canonical-prefix` is the first 8 bytes of `SHA256(canon(content fields))`, rendered as 16 lowercase
-hex. It is the human-legible handle for logs, Telegram, and the frontend — **not** the binding
-commitment. The signature is.
+The reason is key distribution, not convenience. **A signature under a key nobody can attribute is
+decoration.** Signing is the easy half; giving a counterparty a way to learn that the key is ours is
+the hard one, and the EVM identity already has an answer — the recovered address resolves against
+the ERC-8004 identity registry. A fresh Ed25519 key would have had no such story, and inventing one
+is a larger piece of work than all of step 5.
+
+**The cost, stated plainly: the EVM key is a spending key.** The same `EVMProvider` that signs
+receipts also does `transfer_usdc`. The mitigation that matters is domain separation, which is
+exactly what EIP-712 domains are for:
+
+```python
+domain = {"name": "AuraDecisionReceipt", "version": "1", "chainId": <id>}
+#         ^ not "HackathonRiskRouter", and no verifyingContract
+```
+
+Different domain separator means a receipt signature is **not** a valid `TradeIntent` authorisation
+and a trade authorisation is not a valid receipt. `verifyingContract` is absent rather than zeroed —
+a receipt has no contract — which makes the domain structurally different, not merely renamed.
+
+The `ReceiptSignature` message is self-describing: scheme, domain, domain version, chain id, signer,
+signature. A verifier rebuilds the domain from the receipt alone and needs no out-of-band
+configuration, which is what VISION §5.2.2 means by a receipt being self-contained for replay.
+
+**Two formats, not one format with a flag.** `AURA-RECEIPT-V1` is signed; `AURA-RECEIPT-V0-UNSIGNED`
+is what a deployment with no key configured honestly produces. Separate names so a consumer written
+against the signed format cannot be satisfied by a downgrade, and `verify` refuses a version it does
+not recognise rather than best-effort checking it. `VerificationResult.attested` is true only when a
+signature was present *and* recovered to the signer the receipt claims.
+
+**Signing never costs a decision.** The decision is already made and already safe by the time the
+Membrane asks for an attestation; if the key is unreachable the receipt is emitted unsigned. Trading
+the guarantee for the attestation would be the wrong way round.
+
+`canonical-prefix` is the first 8 bytes of `SHA256(content fields)`, 16 lowercase hex, and now
+appears on every `membrane_receipt` log line alongside the outcome, gate and rule set. It is the
+human-legible handle — **not** the binding commitment. The signature is.
 
 ## 4. Worked example
 
@@ -326,12 +373,29 @@ committed beforehand. What they do not learn: the floor, the margin, the cost.
    and returns the record, which travels on `SafetyViolation` for the failing path. Replay tests
    build a fresh Membrane, registry and guard per run, since anything surviving between them is
    state a verifier does not have. Covered by `core/tests/test_{guard,membrane}_derivation.py`.
-4. Add `premise-hash` + salt, and split the policy stamp. **Blocked on a decision, not on code**:
-   who holds the salt and how it rotates. Without that the premise hash is either brute-forceable
-   (§3.1) or unverifiable by anyone but us.
-5. Sign with the identity key; wire `canonical-prefix` into logs and frontend. **Blocked on a
-   decision**: which key signs. The wallet-sanctification key is the obvious candidate, since it
-   would bind receipts to the ERC-8004 identity work.
+4. Add `premise-hash` + salt, and split the policy stamp. **Deferred, and the reason changed.**
+   Not merely "who holds the salt": our premises are low-entropy enough (a two-decimal floor over a
+   bounded range — ~10⁷ candidates for the floor alone) that **anyone holding the salt can recover
+   them by enumeration**. So the salt is exactly as secret as `floor_price`, and a premise hash can
+   never be a counterparty-verifiable field — only a commitment we open to a party already trusted
+   with the floor.
+
+   That is a different threat from VISION's. §8.7.1 salts against *linkage* between receipts, on
+   premises assumed high-entropy (a diagnosis, a customer identity), and records the salt in the
+   policy stamp — which for us would accomplish nothing. Fifth divergence.
+
+   If built, the right primitive is a **per-receipt random nonce stored with the receipt**, not a
+   configured salt: no long-lived secret to rotate or leak in bulk, and opening is selective. That
+   needs receipts persisted somewhere an auditor can read — the same gap that made the bee-keeper
+   half of step 6 unbuildable. Worth answering first: **who opens it, and when?** Absent a concrete
+   dispute or audit flow, this builds a ceremony nobody performs.
+5. ~~Sign with the identity key; wire `canonical-prefix` into logs and frontend.~~ **DONE for the
+   backend.** EIP-712 with the existing EVM key under a domain of its own (§3.7); signing lives in
+   the transaction protein, which owns the key, and verification in `membrane/receipt.py`, which
+   needs none. `canonical_prefix` is on every `membrane_receipt` log line.
+
+   **The frontend half is not done.** It needs the receipt on the wire past the gateway and a place
+   in the UI to show it, which is its own piece of work rather than a line of this one.
 6. ~~Typed `DecisionReceipt` proto message; bee-keeper verifies receipts in CI audit.~~
    **PARTLY DONE.** `DecisionReceipt` exists and `Intent.receipt` replaces the three fields that
    accumulated on `Intent` (7, 8 and 9 are reserved). It adds `claim_hash` / `emission_hash`, so an

--- a/proto/aura/core/v1/metabolism.proto
+++ b/proto/aura/core/v1/metabolism.proto
@@ -270,12 +270,50 @@ message DecisionReceipt {
   // is bound until something signs it.
   string canonical_prefix = 8;
 
-  // Reserved for the fields that need keys or a salt, so nothing reuses these
-  // numbers meanwhile. premise_hash (§3.1) needs the salt decision;
-  // policy_stamp (§3.5) needs the public/committed split; verifier (§3.7) needs
-  // a signing identity.
-  reserved 9, 10, 11;
-  reserved "premise_hash", "policy_stamp", "verifier";
+  // Who signed, and how. Absent on an unsigned receipt, which is the honest
+  // report rather than an error: a deployment with no key configured produces
+  // AURA-RECEIPT-V0-UNSIGNED and says so in `version`.
+  ReceiptSignature signature = 11;
+
+  // Reserved for the two fields still blocked on a decision rather than on
+  // code. premise_hash (§3.1) waits on who holds the salt — and on the finding
+  // that our premises are low-entropy enough that anyone holding it can recover
+  // them, so it can only ever be a commitment we open to a trusted party, not a
+  // counterparty-verifiable field. policy_stamp (§3.5) waits on the
+  // public/committed split.
+  reserved 9, 10;
+  reserved "premise_hash", "policy_stamp";
+}
+
+// The attestation over a receipt's content fields.
+//
+// Self-describing on purpose: a verifier rebuilds the EIP-712 domain from these
+// fields alone and needs no out-of-band configuration to check the signature.
+// A receipt that can only be verified by someone who already knows how we are
+// configured is not much of a receipt.
+message ReceiptSignature {
+  // Signature scheme. `eip712` today.
+  string scheme = 1;
+
+  // EIP-712 domain, kept DISTINCT from the one TradeIntent signs under
+  // (`HackathonRiskRouter`). Domain separation is the standard answer to
+  // signing two kinds of thing with one key: a receipt signature is not a valid
+  // trade authorisation and a trade authorisation is not a valid receipt.
+  //
+  // `verifyingContract` is deliberately absent from the domain — a receipt has
+  // no contract — which makes the domain structurally different from the trade
+  // one, not merely differently named.
+  string domain = 2;
+  string domain_version = 3;
+  uint64 chain_id = 4;
+
+  // The address recovered from a valid signature. A counterparty resolves this
+  // against the ERC-8004 identity registry to learn whether it is ours —
+  // which is the part a fresh signing key would have no answer for.
+  string signer = 5;
+
+  // 0x-prefixed hex.
+  string signature = 6;
 }
 
 message Intent {


### PR DESCRIPTION
Step 5 of `docs/DECISION_RECEIPT.md` §6, backend half. Follows #255, #258, #260, #261.

## The key choice, and why

The receipt is signed with the agent's **existing EVM key** — not the Ed25519 scheme this document originally sketched.

The reason is key distribution, not convenience. **A signature under a key nobody can attribute is decoration.** Signing is the easy half; giving a counterparty a way to learn that the key is ours is the hard one. The EVM identity already has an answer — the recovered address resolves against the ERC-8004 registry. A fresh Ed25519 key would have had no such story, and inventing one is more work than all of step 5.

**The cost, stated rather than glossed: that key is a spending key.** The same `EVMProvider` that signs receipts also does `transfer_usdc`.

The mitigation is domain separation, which is precisely what EIP-712 domains exist for:

```python
domain = {"name": "AuraDecisionReceipt", "version": "1", "chainId": <id>}
#                  ^ not "HackathonRiskRouter"; no verifyingContract
```

`verifyingContract` is **absent rather than zeroed** — a receipt has no contract — so the domain is structurally different, not merely renamed. A receipt signature is not a valid `TradeIntent` authorisation, and a trade authorisation is not a valid receipt.

## Two formats, not one format with a flag

| version | meaning |
|---|---|
| `AURA-RECEIPT-V1` | signed, attributable |
| `AURA-RECEIPT-V0-UNSIGNED` | what a deployment with no key honestly produces |

Separate names so a consumer written against the signed format cannot be satisfied by a downgrade, and `verify` refuses an unrecognised version rather than best-effort checking it. `attested` is true only when a signature was present **and** recovered to the signer the receipt claims — a failed check leaves it `False` rather than `True`-with-failures, so a caller reading one field cannot get the wrong answer.

`ReceiptSignature` is self-describing (scheme, domain, domain version, chain id, signer, signature), so a verifier rebuilds the domain from the receipt alone. A receipt only checkable by someone who already knows how we are configured is not much of a receipt.

## Signing never costs a decision

The decision is already made and already safe by the time an attestation is asked for. An unreachable key yields an unsigned receipt, not a lost negotiation — trading the guarantee for the attestation would be the wrong way round. Covered by `test_a_failing_signer_does_not_cost_the_decision`.

Verification needs no key and lives in `membrane/receipt.py`; signing needs one and lives in the transaction protein, which holds it. The Membrane builds the payload rather than the protein assembling it — two components each building half of a signed document is how they drift into signing different things.

## Also

`canonical_prefix` now appears on every `membrane_receipt` log line with the outcome, gate and rule set. **The frontend half of step 5 is not done** — it needs the receipt on the wire past the gateway and somewhere in the UI to put it, which is its own work.

## Step 4 is deferred, and the analysis changed

Recorded in §3.1 and §6 rather than left as "blocked on a decision". Our premise set is low-entropy — `floor_price` is ~10⁷ candidates alone, ~10¹⁴ with `internal_cost`, hours on one GPU — so **anyone holding the salt can recover the premises by enumeration**. The salt is exactly as secret as `floor_price`, which means a premise hash can *never* be a counterparty-verifiable field; verification and secrecy are mutually exclusive there.

That is a different threat from VISION's. §8.7.1 salts against **linkage**, on premises assumed high-entropy, and records the salt *in the policy stamp* where it is public — which for our threat accomplishes nothing. Fifth divergence.

If built, the right primitive is a per-receipt nonce stored with the receipt, not a configured salt — and the prerequisite is receipts persisted where an auditor can read them, the same gap that made the bee-keeper half of step 6 unbuildable. The question worth answering first is **who opens it, and when**.

## Testing

```
core/tests/test_receipt.py             (+9 signing tests)
core/tests/test_membrane_derivation.py (+4 end-to-end)
core/tests/                            384 passed  (was 372)
ruff check + format                      clean
mypy core/src                            86 files, no issues
buf lint                                 clean
tools/check_fractal_completeness.py      OK
```

One existing test needed updating rather than fixing: `test_an_unknown_format_version_is_refused_outright` used `"AURA-RECEIPT-V1"` as its unknown version, which stopped being unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)