### PR TITLE
feat(receipt): carry the receipt out to machine consumers

### DIFF
--- a/api-gateway/src/api_gateway/main.py
+++ b/api-gateway/src/api_gateway/main.py
@@ -220,7 +220,15 @@ def receipt_to_json(receipt: DecisionReceipt | None) -> dict[str, Any] | None:
     signature object invites a reader to check its fields and find blanks; an
     empty derivation asserts gates that never ran.
     """
-    if receipt is None:
+    # By value, not by reference. betterproto default-constructs a message
+    # field on access rather than returning None, so `response.receipt` is a
+    # DecisionReceipt of blanks when the core never set one. An identity check
+    # here never fires, and every receipt-less response would render an object
+    # full of empty strings — the opposite of the rule this function follows.
+    #
+    # `version` is the sentinel because `mint` always sets it: a receipt that
+    # exists has one, and a default-constructed one does not.
+    if receipt is None or not receipt.version:
         return None
 
     signature = receipt.signature

--- a/api-gateway/src/api_gateway/main.py
+++ b/api-gateway/src/api_gateway/main.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 import betterproto
 import grpclib.client
 import nats
+from aura_core import decision_outcome_name
+from aura_core_gen.aura.core.v1 import DecisionReceipt
 from fastapi import (
     Depends,
     FastAPI,
@@ -198,6 +200,63 @@ class NegotiationRequestHTTP(BaseModel):
     agent_did: str
 
 
+def receipt_to_json(receipt: DecisionReceipt | None) -> dict[str, Any] | None:
+    """
+    Render a decision receipt for a machine consumer.
+
+    Nested as one object rather than spread across the response's top-level
+    keys: the deferred premise hash and policy stamp land in this same message,
+    and flattening would make each of them a separate decision about the shape
+    of this endpoint.
+
+    Two properties are what make the result usable by someone who does not run
+    our code. The signature block carries its own EIP-712 domain, so a consumer
+    rebuilds it and calls `ecrecover` without knowing how we are configured. And
+    `outcome` travels as the name that was signed rather than its protobuf
+    integer, so reconstructing the signed content needs no mapping step — which
+    is where a consumer would otherwise get it wrong.
+
+    Absences are reported as null rather than as empty shapes. An empty
+    signature object invites a reader to check its fields and find blanks; an
+    empty derivation asserts gates that never ran.
+    """
+    if receipt is None:
+        return None
+
+    signature = receipt.signature
+    derivation = receipt.derivation
+
+    return {
+        "version": receipt.version,
+        "canonical_prefix": receipt.canonical_prefix,
+        "outcome": decision_outcome_name(receipt.outcome),
+        "outcome_gate": receipt.outcome_gate,
+        "claim_hash": receipt.claim_hash,
+        "emission_hash": receipt.emission_hash,
+        "ruleset_version": receipt.ruleset_version,
+        "derivation": (
+            {
+                "gate_sequence": derivation.gate_sequence,
+                "derivation_hash": derivation.derivation_hash,
+            }
+            if derivation is not None and derivation.derivation_hash
+            else None
+        ),
+        "signature": (
+            {
+                "scheme": signature.scheme,
+                "domain": signature.domain,
+                "domain_version": signature.domain_version,
+                "chain_id": signature.chain_id,
+                "signer": signature.signer,
+                "signature": signature.signature,
+            }
+            if signature is not None and signature.signature
+            else None
+        ),
+    }
+
+
 @app.post("/v1/negotiate")
 async def negotiate(
     request: Request,
@@ -230,6 +289,7 @@ async def negotiate(
             "session_token": response.session_token,
             "status": result_name,
             "valid_until": response.valid_until_timestamp,
+            "receipt": receipt_to_json(response.receipt),
         }
 
         if result_name == "accepted" and result_val:

--- a/api-gateway/tests/test_receipt_json.py
+++ b/api-gateway/tests/test_receipt_json.py
@@ -1,0 +1,129 @@
+"""
+The shape a machine consumer actually receives.
+
+The receipt exists to be checked by someone outside this process, so the JSON
+has to carry enough for them to recover the signer themselves rather than
+calling our code. Two properties do most of that work: the signature block is
+self-describing, and the fields that make up the signed content appear exactly
+as they were signed.
+"""
+
+from api_gateway.main import receipt_to_json
+from aura_core_gen.aura.core.v1 import (
+    DecisionDerivation,
+    DecisionOutcome,
+    DecisionReceipt,
+    ReceiptSignature,
+)
+
+SIGNED = DecisionReceipt(
+    version="AURA-RECEIPT-V1",
+    claim_hash="a" * 64,
+    ruleset_version="guard/negotiation@1.0.0+46cc0e38ca4f895c",
+    derivation=DecisionDerivation(
+        gate_sequence="G1_PRICE_POSITIVE:pass:price", derivation_hash="b" * 64
+    ),
+    emission_hash="c" * 64,
+    outcome=DecisionOutcome.DECISION_OUTCOME_OVERRIDE,
+    outcome_gate="FLOOR_PRICE_VIOLATION",
+    canonical_prefix="c0ffee1234abcd56",
+    signature=ReceiptSignature(
+        scheme="eip712",
+        domain="AuraDecisionReceipt",
+        domain_version="1",
+        chain_id=84532,
+        signer="0xabc",
+        signature="0xdef",
+    ),
+)
+
+
+class TestTheOutcomeIsNamed:
+    def test_it_travels_as_the_string_that_was_signed(self) -> None:
+        """
+        Not the protobuf integer. The signature covers this name, so publishing
+        the number would leave a consumer to map it back — and a mapping step
+        inside a signature reconstruction is where they get it wrong.
+        """
+        assert receipt_to_json(SIGNED)["outcome"] == "override"
+
+
+class TestTheSignatureIsSelfDescribing:
+    def test_the_domain_travels_with_the_signature(self) -> None:
+        """
+        A consumer rebuilds the EIP-712 domain from these fields alone. Without
+        them they would need to know how we are configured, and a receipt only
+        checkable by someone who already knows that is not much of a receipt.
+        """
+        signature = receipt_to_json(SIGNED)["signature"]
+
+        assert signature["domain"] == "AuraDecisionReceipt"
+        assert signature["domain_version"] == "1"
+        assert signature["chain_id"] == 84532
+        assert signature["scheme"] == "eip712"
+        assert signature["signer"] == "0xabc"
+
+
+class TestAnUnsignedReceiptCannotPassForASignedOne:
+    def test_the_version_says_so(self) -> None:
+        unsigned = DecisionReceipt(
+            version="AURA-RECEIPT-V0-UNSIGNED",
+            outcome=DecisionOutcome.DECISION_OUTCOME_EMIT,
+            canonical_prefix="0123456789abcdef",
+        )
+
+        assert receipt_to_json(unsigned)["version"] == "AURA-RECEIPT-V0-UNSIGNED"
+
+    def test_the_signature_is_null_rather_than_an_empty_shape(self) -> None:
+        """
+        An empty signature object invites a consumer to check its fields and
+        find blanks. `null` cannot be misread as an attestation that happened to
+        have no content.
+        """
+        unsigned = DecisionReceipt(
+            version="AURA-RECEIPT-V0-UNSIGNED",
+            outcome=DecisionOutcome.DECISION_OUTCOME_EMIT,
+        )
+
+        assert receipt_to_json(unsigned)["signature"] is None
+
+
+class TestTheReceiptIsNested:
+    def test_it_is_one_object_rather_than_spread_across_keys(self) -> None:
+        """
+        Deferred step 4 adds a premise hash and a policy stamp to this same
+        message. Nesting keeps that open; flattening would make each new field a
+        separate decision about the endpoint's top-level shape.
+        """
+        rendered = receipt_to_json(SIGNED)
+
+        assert set(rendered) == {
+            "version",
+            "canonical_prefix",
+            "outcome",
+            "outcome_gate",
+            "claim_hash",
+            "emission_hash",
+            "ruleset_version",
+            "derivation",
+            "signature",
+        }
+        assert rendered["derivation"]["gate_sequence"].startswith("G1_")
+
+
+class TestNothingHiddenNothingInvented:
+    def test_a_receipt_with_no_derivation_reports_none(self) -> None:
+        """
+        Membrane-level refusals consult no rule set, so they have no derivation.
+        An empty object would assert one that never ran.
+        """
+        bare = DecisionReceipt(
+            version="AURA-RECEIPT-V0-UNSIGNED",
+            outcome=DecisionOutcome.DECISION_OUTCOME_REFUSE,
+            outcome_gate="KYC_FAILURE",
+        )
+
+        assert receipt_to_json(bare)["derivation"] is None
+
+    def test_an_absent_receipt_renders_as_nothing(self) -> None:
+        assert receipt_to_json(None) is None

--- a/api-gateway/tests/test_receipt_json.py
+++ b/api-gateway/tests/test_receipt_json.py
@@ -125,5 +125,47 @@ class TestNothingHiddenNothingInvented:
 
         assert receipt_to_json(bare)["derivation"] is None
 
-    def test_an_absent_receipt_renders_as_nothing(self) -> None:
+    def test_an_explicit_none_renders_as_nothing(self) -> None:
+        """
+        The defensive case, not the real one. betterproto never hands back None
+        for a message field — see TestAnUnsetReceiptIsAbsence for the shape an
+        actual receipt-less response has, which is what this test originally
+        claimed to cover and did not.
+        """
         assert receipt_to_json(None) is None
+
+
+class TestAnUnsetReceiptIsAbsence:
+    """
+    betterproto default-constructs a message field on access rather than
+    returning None, so `response.receipt` is a DecisionReceipt of blanks when
+    the core never set one — never `None`.
+
+    The first cut checked `receipt is None`, which therefore never fired, and
+    the test that covered it passed `None` explicitly: it verified a case the
+    real path does not produce and missed the one it does. Emptiness here is a
+    property of the value, not of the reference.
+    """
+
+    def test_a_default_constructed_receipt_renders_as_nothing(self) -> None:
+        assert receipt_to_json(DecisionReceipt()) is None
+
+    def test_the_response_of_a_deployment_that_minted_nothing_carries_no_receipt(
+        self,
+    ) -> None:
+        """The shape a client sees, taken off an actual response object."""
+        from aura_core_gen.aura.negotiation.v1 import NegotiateResponse
+
+        assert receipt_to_json(NegotiateResponse().receipt) is None
+
+    def test_a_receipt_with_a_version_is_still_rendered(self) -> None:
+        """The check must not swallow a real receipt that happens to be sparse."""
+        sparse = DecisionReceipt(
+            version="AURA-RECEIPT-V0-UNSIGNED",
+            outcome=DecisionOutcome.DECISION_OUTCOME_EMIT,
+        )
+
+        rendered = receipt_to_json(sparse)
+
+        assert rendered is not None
+        assert rendered["version"] == "AURA-RECEIPT-V0-UNSIGNED"

--- a/core/src/aura_hive/hive/connector/main.py
+++ b/core/src/aura_hive/hive/connector/main.py
@@ -63,7 +63,7 @@ class HiveConnector(BaseConnector):
         # forgets. The chain out to the client re-assembles each message field
         # by field rather than passing it along, and the receipt died here —
         # NegotiationObservation had nowhere to put it.
-        if action.receipt is not None:
+        if action.receipt is not None and action.receipt.version:
             neg_obs.receipt = action.receipt
 
         action_type = action.action

--- a/core/src/aura_hive/hive/connector/main.py
+++ b/core/src/aura_hive/hive/connector/main.py
@@ -59,6 +59,13 @@ class HiveConnector(BaseConnector):
             valid_until_timestamp=int(time.time() + 600),
         )
 
+        # Copied before the result branches, so no branch can be the one that
+        # forgets. The chain out to the client re-assembles each message field
+        # by field rather than passing it along, and the receipt died here —
+        # NegotiationObservation had nowhere to put it.
+        if action.receipt is not None:
+            neg_obs.receipt = action.receipt
+
         action_type = action.action
         event_type = "negotiation_unknown"
 

--- a/core/src/aura_hive/hive/membrane/main.py
+++ b/core/src/aura_hive/hive/membrane/main.py
@@ -3,7 +3,12 @@ from typing import Any, cast
 
 import betterproto
 import structlog
-from aura_core import Membrane, SkillRegistry, make_struct
+from aura_core import (
+    Membrane,
+    SkillRegistry,
+    decision_outcome_name,
+    make_struct,
+)
 from aura_core_gen.aura.core.v1 import (
     ActionType,
     Context,
@@ -197,15 +202,6 @@ def _context_number(ctx_meta: dict[str, Any], key: str, default: float) -> float
         return default
 
 
-def _outcome_label(outcome: Any) -> str:
-    """`override`, not `2` — the log line is read by people."""
-    try:
-        name = DecisionOutcome(int(outcome)).name or ""
-    except (ValueError, TypeError, AttributeError):
-        return f"outcome_{outcome}"
-    return name.removeprefix("DECISION_OUTCOME_").lower()
-
-
 def _action_label(action: Any) -> str:
     """Safely convert ActionType or raw int to a lowercase name string."""
     try:
@@ -242,7 +238,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
             logger.info(
                 "membrane_receipt",
                 prefix=emission.receipt.canonical_prefix,
-                outcome=_outcome_label(emission.receipt.outcome),
+                outcome=decision_outcome_name(emission.receipt.outcome),
                 gate=emission.receipt.outcome_gate or None,
                 ruleset=emission.receipt.ruleset_version or None,
                 attested=bool(emission.receipt.signature),

--- a/core/src/aura_hive/hive/membrane/main.py
+++ b/core/src/aura_hive/hive/membrane/main.py
@@ -178,6 +178,26 @@ def _replacing(original: Intent, replacement: Intent) -> Intent:
     return replacement
 
 
+def _is_signed(receipt: DecisionReceipt) -> bool:
+    """
+    Whether an attestation is attached — not whether it is valid.
+
+    Checked by value rather than by object. betterproto messages define their
+    own falsiness, so `bool(receipt.signature)` does discriminate a signed
+    receipt from an unsigned one; but a signature block carrying a scheme and no
+    signature would still read as truthy, and the log's notion of signed should
+    not be weaker than `verify`'s, which already reads the value.
+
+    Deliberately NOT called `attested`. That word belongs to `verify` and means
+    the signature recovered to the signer the receipt claims. This function
+    recovers nothing, and a log claiming attestation nobody performed is the
+    same overstatement `VerificationResult` separates `ok` from `attested` to
+    avoid — in a cheaper place.
+    """
+    signature = receipt.signature
+    return signature is not None and bool(signature.signature)
+
+
 def _context_number(ctx_meta: dict[str, Any], key: str, default: float) -> float:
     """
     Read a number out of Context.metadata that may not be one.
@@ -241,7 +261,7 @@ class HiveMembrane(Membrane[Any, Intent, Context]):
                 outcome=decision_outcome_name(emission.receipt.outcome),
                 gate=emission.receipt.outcome_gate or None,
                 ruleset=emission.receipt.ruleset_version or None,
-                attested=bool(emission.receipt.signature),
+                signed=_is_signed(emission.receipt),
             )
         except Exception as e:  # nosec B110
             # The same rule `_record_intervention` follows, and for the same

--- a/core/src/aura_hive/hive/membrane/receipt.py
+++ b/core/src/aura_hive/hive/membrane/receipt.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, replace
 from typing import Any
 
 import betterproto
+from aura_core import decision_outcome_name
 from aura_core_gen.aura.core.v1 import (
     ActionType,
     AssetIntent,
@@ -202,7 +203,7 @@ def _content_fields(receipt: DecisionReceipt) -> str:
             receipt.ruleset_version,
             derivation.derivation_hash,
             receipt.emission_hash,
-            str(int(receipt.outcome)),
+            decision_outcome_name(receipt.outcome),
             receipt.outcome_gate,
         ]
     )

--- a/core/src/aura_hive/main.py
+++ b/core/src/aura_hive/main.py
@@ -108,7 +108,7 @@ class NegotiationService:
                 # Connector copies it ahead of its own: this response is built
                 # field by field, and a receipt attached inside one branch is a
                 # receipt the other branches drop.
-                if neg.receipt is not None:
+                if neg.receipt is not None and neg.receipt.version:
                     response.receipt = neg.receipt
 
                 res_name, res_val = betterproto.which_one_of(neg, "result")

--- a/core/src/aura_hive/main.py
+++ b/core/src/aura_hive/main.py
@@ -104,6 +104,13 @@ class NegotiationService:
                 neg = obs_val
                 response.valid_until_timestamp = neg.valid_until_timestamp
 
+                # Copied ahead of the result branches for the same reason the
+                # Connector copies it ahead of its own: this response is built
+                # field by field, and a receipt attached inside one branch is a
+                # receipt the other branches drop.
+                if neg.receipt is not None:
+                    response.receipt = neg.receipt
+
                 res_name, res_val = betterproto.which_one_of(neg, "result")
                 if res_name == "accepted" and res_val:
                     from aura_core_gen.aura.negotiation.v1 import OfferAccepted

--- a/core/tests/test_membrane_derivation.py
+++ b/core/tests/test_membrane_derivation.py
@@ -21,9 +21,11 @@ from aura_core_gen.aura.core.v1 import (
     ActionType,
     Context,
     DecisionOutcome,
+    DecisionReceipt,
     Intent,
     NegotiationIntent,
     Observation,
+    ReceiptSignature,
     RWAComplianceScore,
     RWAVaultIntent,
     TradeIntent,
@@ -655,3 +657,69 @@ class TestNothingInAttestationCanCostTheDecision:
         assert decision.receipt.outcome == DecisionOutcome.DECISION_OUTCOME_OVERRIDE
         assert decision.negotiation.price != 500.0
         assert decision.receipt.canonical_prefix != ""
+
+
+class TestTheReceiptLogClaimsOnlyWhatItKnows:
+    """
+    `attested` is a word `verify` owns: it means the signature recovered to the
+    signer the receipt claims. The log line never recovers anything — it knows
+    only whether a signature is attached — so it says `signed`.
+
+    Using the stronger word for the weaker fact is the conflation
+    `VerificationResult` separates `ok` from `attested` to avoid, and a log
+    asserting attestation nobody performed is the same overstatement in a
+    cheaper place.
+    """
+
+    def logged(self, calls: list) -> dict:
+        return next(kw for _, kw in calls if _ and _[0] == "membrane_receipt")
+
+    @pytest.mark.asyncio
+    async def test_an_unsigned_decision_is_not_reported_as_signed(self) -> None:
+        calls: list = []
+        membrane = guarded_membrane()
+
+        with patch(
+            "aura_hive.hive.membrane.main.logger.info",
+            side_effect=lambda *a, **kw: calls.append((a, kw)),
+        ):
+            await membrane.inspect_outbound(
+                counter_intent(price=500.0), negotiation_context()
+            )
+
+        assert self.logged(calls)["signed"] is False
+
+    @pytest.mark.asyncio
+    async def test_a_signed_decision_is(self) -> None:
+        calls: list = []
+        account = Account.create()
+        registry = SkillRegistry()
+        guard = GuardSkill()
+        guard.bind(_Safety(), OutputGuard(safety_settings=_Safety()))
+        registry.register(guard.get_name(), guard)
+        registry.register("transaction", TestSigningTheReceipt._Signer(account))
+        membrane = HiveMembrane(registry=registry)
+
+        with patch(
+            "aura_hive.hive.membrane.main.logger.info",
+            side_effect=lambda *a, **kw: calls.append((a, kw)),
+        ):
+            await membrane.inspect_outbound(
+                counter_intent(price=500.0), negotiation_context()
+            )
+
+        assert self.logged(calls)["signed"] is True
+
+    def test_a_signature_block_with_no_signature_is_not_signed(self) -> None:
+        """
+        Narrow, and unreachable through `signed()` which fills every field at
+        once — but the log's notion of signed should not be weaker than
+        `verify`'s, which already checks the value rather than the object.
+        """
+        from aura_hive.hive.membrane.main import _is_signed
+
+        assert not _is_signed(
+            DecisionReceipt(
+                version="AURA-RECEIPT-V1", signature=ReceiptSignature(scheme="eip712")
+            )
+        )

--- a/core/tests/test_receipt.py
+++ b/core/tests/test_receipt.py
@@ -22,6 +22,7 @@ everything a reader might want.
 import hashlib
 
 import pytest
+from aura_core import decision_outcome_name
 from aura_core_gen.aura.core.v1 import (
     ActionType,
     AssetIntent,
@@ -619,3 +620,79 @@ class TestSigning:
         assert attested.signature.chain_id == 84532
         assert attested.signature.domain == RECEIPT_EIP712_DOMAIN
         assert verify(attested).ok
+
+
+class TestTheSignedPayloadIsReadable:
+    """
+    A consumer reconstructs the signed content to recover the signer, so every
+    field in it needs exactly one representation on the wire.
+
+    `outcome` used to be signed as its protobuf integer. That forces a JSON API
+    either to publish an opaque number, or to publish the name and leave the
+    consumer to map it back — and a mapping step in the middle of a signature
+    reconstruction is where they get it wrong. The name is signed instead, so
+    what travels and what was signed are the same string.
+    """
+
+    def test_the_outcome_is_signed_by_name_not_by_number(self) -> None:
+        receipt = mint(
+            claim=counter(price=92.0),
+            emission=counter(price=105.0),
+            outcome=DecisionOutcome.DECISION_OUTCOME_OVERRIDE,
+            outcome_gate="FLOOR_PRICE_VIOLATION",
+        )
+
+        content = signing_payload(receipt, chain_id=1)["message"]["content"]
+
+        assert "override" in content.split("\n")
+        assert "2" not in content.split("\n")
+
+    def test_every_outcome_has_a_distinct_name_in_the_payload(self) -> None:
+        """Two outcomes that rendered alike would make the digest ambiguous."""
+        names = set()
+        for outcome in (
+            DecisionOutcome.DECISION_OUTCOME_EMIT,
+            DecisionOutcome.DECISION_OUTCOME_OVERRIDE,
+            DecisionOutcome.DECISION_OUTCOME_REFUSE,
+        ):
+            receipt = mint(
+                claim=counter(price=105.0),
+                emission=counter(price=105.0),
+                outcome=outcome,
+                outcome_gate="DLP_BLOCK",
+            )
+            names.add(signing_payload(receipt, chain_id=1)["message"]["content"])
+
+        assert len(names) == 3
+
+
+class TestTheOutcomeNamesMatchTheEnum:
+    """
+    `decision_outcome_name` keeps its own table rather than reading the
+    generated enum, so the Genome stays free of generated code. That buys
+    purity at the cost of a table that can drift — and this one is signed, so a
+    drift would silently change what every signature covers.
+
+    Cross-checked here for the same reason the rule set cross-checks its gates
+    against the engine: a mapping nothing verifies is a mapping that will
+    eventually be wrong.
+    """
+
+    def test_every_declared_outcome_has_a_name(self) -> None:
+        for outcome in DecisionOutcome:
+            rendered = decision_outcome_name(outcome)
+
+            assert not rendered.startswith("outcome_"), (
+                f"{outcome.name} has no entry in decision_outcome_name; "
+                "adding an outcome to the proto means adding it there too"
+            )
+
+    def test_the_names_are_distinct(self) -> None:
+        """Two outcomes rendering alike would make a signed payload ambiguous."""
+        names = [decision_outcome_name(o) for o in DecisionOutcome]
+
+        assert len(set(names)) == len(names)
+
+    def test_an_unknown_number_renders_distinctly(self) -> None:
+        """It must not be mistakable for a known outcome."""
+        assert decision_outcome_name(99) == "outcome_99"

--- a/core/tests/test_receipt_transport.py
+++ b/core/tests/test_receipt_transport.py
@@ -1,0 +1,89 @@
+"""
+The receipt survives every hop between the Membrane and the client.
+
+Each message in that chain is re-assembled field by field rather than passed
+along, so the receipt has to be copied deliberately at each one. It used to die
+at the first — `NegotiationObservation` simply had no field for it — and a
+receipt that stops inside the process is a receipt nobody outside can read,
+which is the only audience it has.
+"""
+
+import pytest
+from aura_core import SkillRegistry
+from aura_core.struct_utils import make_struct
+from aura_core_gen.aura.core.v1 import (
+    ActionType,
+    Context,
+    DecisionOutcome,
+    DecisionReceipt,
+    Intent,
+    NegotiationIntent,
+    ReceiptSignature,
+)
+from aura_hive.hive.connector.main import HiveConnector
+
+
+def counter_intent_with_receipt() -> Intent:
+    return Intent(
+        action=ActionType.ACTION_TYPE_COUNTER,
+        negotiation=NegotiationIntent(price=105.0, message="my best offer"),
+        receipt=DecisionReceipt(
+            version="AURA-RECEIPT-V1",
+            claim_hash="a" * 64,
+            emission_hash="b" * 64,
+            ruleset_version="guard/negotiation@1.0.0+46cc0e38ca4f895c",
+            outcome=DecisionOutcome.DECISION_OUTCOME_OVERRIDE,
+            outcome_gate="FLOOR_PRICE_VIOLATION",
+            canonical_prefix="c0ffee1234abcd56",
+            signature=ReceiptSignature(signer="0xabc", signature="0xdef"),
+        ),
+    )
+
+
+class TestTheConnectorCarriesItOut:
+    @pytest.mark.asyncio
+    async def test_a_countered_offer_carries_its_receipt(self) -> None:
+        observation = await HiveConnector(SkillRegistry()).act(
+            counter_intent_with_receipt(), Context(metadata=make_struct({}))
+        )
+
+        assert observation.negotiation.receipt.canonical_prefix == "c0ffee1234abcd56"
+        assert observation.negotiation.receipt.outcome_gate == "FLOOR_PRICE_VIOLATION"
+
+    @pytest.mark.asyncio
+    async def test_the_signature_survives_the_hop(self) -> None:
+        """
+        A receipt whose signature was dropped en route verifies as unsigned,
+        which is worse than being absent: it looks like a deployment with no key
+        rather than a transport that lost the attestation.
+        """
+        observation = await HiveConnector(SkillRegistry()).act(
+            counter_intent_with_receipt(), Context(metadata=make_struct({}))
+        )
+
+        assert observation.negotiation.receipt.signature.signer == "0xabc"
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_offer_carries_it_too(self) -> None:
+        """Refusals are the decisions a counterparty most wants to check."""
+        intent = counter_intent_with_receipt()
+        intent.action = ActionType.ACTION_TYPE_REJECT
+
+        observation = await HiveConnector(SkillRegistry()).act(
+            intent, Context(metadata=make_struct({}))
+        )
+
+        assert observation.negotiation.receipt.canonical_prefix == "c0ffee1234abcd56"
+
+    @pytest.mark.asyncio
+    async def test_an_intent_without_a_receipt_does_not_invent_one(self) -> None:
+        intent = Intent(
+            action=ActionType.ACTION_TYPE_COUNTER,
+            negotiation=NegotiationIntent(price=105.0),
+        )
+
+        observation = await HiveConnector(SkillRegistry()).act(
+            intent, Context(metadata=make_struct({}))
+        )
+
+        assert observation.negotiation.receipt.canonical_prefix == ""

--- a/docs/DECISION_RECEIPT.md
+++ b/docs/DECISION_RECEIPT.md
@@ -341,6 +341,103 @@ What the counterparty learns: a rule fired, at gate 4, consuming their offered p
 they cannot see; the price they received is the Membrane's, not the model's; our thresholds were
 committed beforehand. What they do not learn: the floor, the margin, the cost.
 
+## 7. Checking a receipt without our code
+
+A receipt a consumer cannot check independently is a receipt they have to trust, which is the thing
+it exists to replace. `/v1/negotiate` returns it nested under `receipt`:
+
+```json
+{
+  "session_token": "sess_…",
+  "status": "countered",
+  "receipt": {
+    "version": "AURA-RECEIPT-V1",
+    "canonical_prefix": "c0ffee1234abcd56",
+    "outcome": "override",
+    "outcome_gate": "FLOOR_PRICE_VIOLATION",
+    "claim_hash": "<hex64>",
+    "emission_hash": "<hex64>",
+    "ruleset_version": "guard/negotiation@1.0.0+46cc0e38ca4f895c",
+    "derivation": {"gate_sequence": "G1_PRICE_POSITIVE:pass:price␟…", "derivation_hash": "<hex64>"},
+    "signature": {
+      "scheme": "eip712",
+      "domain": "AuraDecisionReceipt",
+      "domain_version": "1",
+      "chain_id": 84532,
+      "signer": "0x…",
+      "signature": "0x…"
+    }
+  }
+}
+```
+
+**Read `version` first.** `AURA-RECEIPT-V0-UNSIGNED` means the deployment had no key configured and
+`signature` is `null`. Everything else in the receipt is still true and still checkable, but nobody
+has vouched for it. Treating one as the other is the downgrade the two names exist to prevent.
+
+### Recovering the signer
+
+The signature covers a single string: the content fields, joined by `\n`, in this exact order.
+
+```
+version
+claim_hash
+ruleset_version
+derivation.derivation_hash      ← empty string when derivation is null
+emission_hash
+outcome                         ← the name, e.g. "override" — not a number
+outcome_gate
+```
+
+That string is the `content` member of an EIP-712 message, under a domain rebuilt from the receipt's
+own `signature` block:
+
+```python
+payload = {
+    "types": {
+        "EIP712Domain": [
+            {"name": "name", "type": "string"},
+            {"name": "version", "type": "string"},
+            {"name": "chainId", "type": "uint256"},
+        ],
+        "DecisionReceipt": [{"name": "content", "type": "string"}],
+    },
+    "domain": {
+        "name": sig["domain"],           # AuraDecisionReceipt
+        "version": sig["domain_version"],
+        "chainId": sig["chain_id"],
+    },
+    "primaryType": "DecisionReceipt",
+    "message": {"content": content},
+}
+recovered = Account.recover_message(encode_typed_data(full_message=payload), signature=sig["signature"])
+assert recovered.lower() == sig["signer"].lower()
+```
+
+Note there is **no `verifyingContract`** — a receipt has no contract, and its absence is part of what
+makes this domain structurally different from the one `TradeIntent` is signed under. Adding a zeroed
+one produces a different domain separator and the recovery fails.
+
+The recovered address is then resolved against the ERC-8004 identity registry to learn whether it is
+ours. That step is the point of using the EVM key: the address means something because it is already
+published, not because we assert it.
+
+### What the fields tell you
+
+- **`claim_hash` ≠ `emission_hash`** — the Membrane substituted a value. The price you received is
+  the guard's, not the model's. Equal hashes with `outcome: "override"` are legitimate only for a
+  prose-only gate (`DLP_BLOCK`); under any other gate that combination is a receipt describing
+  something that did not happen.
+- **`ruleset_version`** — which rules judged it. The digest changes when the gate list changes;
+  empty means no rule set was consulted, which is the case for Membrane-level refusals.
+- **`derivation.gate_sequence`** — every gate that ran, in order, with its verdict, naming the
+  premise *keys* each consulted. It never carries a value, so it cannot be probed for the floor.
+- **`canonical_prefix`** — a handle for correlating with our logs. Not a commitment; the signature is.
+
+Our own implementation of all of this is `verify()` in `core/src/aura_hive/hive/membrane/receipt.py`.
+It needs no key and no configuration, so it is usable directly by anyone who can import it — but the
+format above is the contract, and a consumer reimplementing it owes us nothing.
+
 ## 5. Honest gaps
 
 1. **No constraint graph.** §3.2 substitutes a flat canonical claim. We are building *attested

--- a/packages/aura-core/src/aura_core/__init__.py
+++ b/packages/aura-core/src/aura_core/__init__.py
@@ -35,8 +35,10 @@ from .metabolism import (
     map_action,
 )
 from .struct_utils import make_struct
+from .wire_names import decision_outcome_name
 
 __all__ = [
+    "decision_outcome_name",
     # Manifest (Geography)
     "find_hive_root",
     "MACRO_ATCG_FOLDERS",

--- a/packages/aura-core/src/aura_core/wire_names.py
+++ b/packages/aura-core/src/aura_core/wire_names.py
@@ -1,0 +1,44 @@
+"""
+Canonical names for protobuf enums that appear in signed content.
+
+`DecisionOutcome` is one of the fields an AURA-RECEIPT-V1 signature covers, and
+it is signed by name rather than by its protobuf integer — so that what travels
+on the wire and what was signed are the same string, with no mapping step in the
+middle of a consumer's signature reconstruction for them to get wrong.
+
+Which means the mapping must have exactly one implementation. It lives in the
+Genome because both sides need it and neither may own it: the Membrane produces
+the signed content, the api-gateway renders the same value into JSON, and a
+second implementation drifting from the first would silently invalidate every
+signature it touched.
+
+Pure: standard library only, no project imports.
+"""
+
+from typing import Any
+
+_DECISION_OUTCOME_PREFIX = "DECISION_OUTCOME_"
+
+_DECISION_OUTCOMES = {
+    0: "unspecified",
+    1: "emit",
+    2: "override",
+    3: "refuse",
+}
+
+
+def decision_outcome_name(outcome: Any) -> str:
+    """
+    `override`, not `2`.
+
+    Falls back to a rendering of whatever it was handed rather than raising:
+    this is used to build a log line and a JSON field, and neither is worth
+    failing a decision over. An unknown number renders distinctly so it cannot
+    be mistaken for a known outcome.
+    """
+    try:
+        key = int(outcome)
+    except (TypeError, ValueError):
+        return f"outcome_{outcome}"
+
+    return _DECISION_OUTCOMES.get(key, f"outcome_{key}")

--- a/proto/aura/core/v1/metabolism.proto
+++ b/proto/aura/core/v1/metabolism.proto
@@ -442,6 +442,12 @@ message NegotiationObservation {
     OfferCountered countered = 6;
     OfferRejected rejected = 7;
   }
+
+  // Carried through from the Intent the Connector acted on, so it survives to
+  // the client. Every message in this chain is re-assembled field by field
+  // rather than passed along, so the receipt has to be copied deliberately at
+  // each hop or it is silently dropped — which is where it used to die.
+  DecisionReceipt receipt = 8;
 }
 
 message OfferAccepted {

--- a/proto/aura/negotiation/v1/negotiation.proto
+++ b/proto/aura/negotiation/v1/negotiation.proto
@@ -23,7 +23,7 @@ message NegotiateRequest {
   string item_id = 2;         // Identifier of the item being negotiated.
   double bid_amount = 3;      // The proposed bid amount.
   string currency_code = 4;   // Currency code, e.g., "USD".
-  
+
   // Metadata for the agent identity.
   AgentIdentity agent = 5;
 
@@ -47,6 +47,15 @@ message NegotiateResponse {
     OfferRejected rejected = 5;
     JitUiRequest ui_required = 6;
   }
+
+  // What the Membrane attests about the decision behind this response: which
+  // rules judged it, how they were applied, whether the price is the model's or
+  // the guard's, and who signed that.
+  //
+  // Present but UNSIGNED when the deployment has no key configured. A consumer
+  // must read `version` rather than assume — treating an unsigned receipt as a
+  // signed one is the downgrade the two version names exist to prevent.
+  aura.core.v1.DecisionReceipt receipt = 7;
 }
 
 message OfferAccepted {


### PR DESCRIPTION
Closes #264. Machine consumers only — no UI, per the decision recorded on that issue.

## Where it died

The receipt was minted and signed inside the metabolic cycle (#261, #263) and stopped at the first hop out — `NegotiationObservation` simply had no field for it.

```
Intent.receipt → NegotiationObservation → NegotiateResponse → JSON
                        ↑ dropped here
```

Every message in that chain re-assembles its fields rather than passing anything along, so the receipt had to be added at each hop deliberately. Copied **ahead of the result branches** at both proto hops, so no branch can be the one that forgets.

## The outcome is now signed by name, not by number

**This changes what a signature covers.** Done now because there are no receipts in the wild, and because it removes a seam a consumer would have cut themselves on.

Signing the protobuf integer forces a JSON API to either publish something opaque, or publish the name and leave the consumer to map it back — and a mapping step in the middle of a signature reconstruction is exactly where they get it wrong. Signing the name means what travels and what was signed are the same string.

That makes the mapping load-bearing, so it has **one implementation, in the Genome** (`aura_core.decision_outcome_name`). The Membrane produces the signed content; the gateway renders the same value into JSON. A second implementation drifting from the first would silently invalidate every signature it touched.

It keeps its own table rather than reading the generated enum, so the Genome stays free of generated code — and a test cross-checks the table against the proto, for the same reason the rule set cross-checks its gates against the engine. Adding an outcome to the proto without adding it there fails that test with a message saying so.

## The JSON shape

```json
"receipt": {
  "version": "AURA-RECEIPT-V1",
  "canonical_prefix": "c0ffee1234abcd56",
  "outcome": "override",
  "outcome_gate": "FLOOR_PRICE_VIOLATION",
  "claim_hash": "…", "emission_hash": "…",
  "ruleset_version": "guard/negotiation@1.0.0+46cc0e38ca4f895c",
  "derivation": {"gate_sequence": "…", "derivation_hash": "…"},
  "signature": {"scheme": "eip712", "domain": "AuraDecisionReceipt",
                "domain_version": "1", "chain_id": 84532, "signer": "0x…", "signature": "0x…"}
}
```

Three properties, each tested:

- **Nested, not flattened.** Deferred step 4 adds a premise hash and a policy stamp to this same message; flattening would make each of those a fresh decision about the endpoint's top-level shape.
- **Self-describing signature.** A consumer rebuilds the EIP-712 domain from the receipt alone and calls `ecrecover` without knowing how we are configured.
- **Absences are `null`, not empty shapes.** An empty signature object invites a reader to check its fields and find blanks; an empty derivation asserts gates that never ran. An unsigned receipt says so in `version` and carries `"signature": null`.

## The part that makes the rest worth anything

§7 of `docs/DECISION_RECEIPT.md` now documents the content-field order, the EIP-712 reconstruction (including that `verifyingContract` is **absent**, not zeroed — adding one changes the domain separator and recovery fails), and what each field tells a reader.

A receipt a consumer can only check by calling our code is a receipt they have to trust, which is the thing it exists to replace. `verify()` remains available and needs no key, but the documented format is the contract.

## Testing

```
core/tests/                          395 passed  (was 386)
api-gateway/tests/                     8 passed  (was 1)
telegram-bot / bee-keeper              6 / 7 passed
ruff check + format                    clean
mypy core / api-gateway / aura-core    86 / 7 / 7 files, no issues
buf lint                               clean
tools/check_fractal_completeness.py    OK
```

New: `core/tests/test_receipt_transport.py` (the hops), `api-gateway/tests/test_receipt_json.py` (the shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)