### PR TITLE
build: one ruff, resolved from the lockfile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,15 +13,33 @@ repos:
         exclude: ^deploy/.*/templates/.*\.yaml$  # Exclude Helm templates
       - id: check-added-large-files
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format
-
   - repo: local
     hooks:
+      # The workspace's ruff, not a second copy pinned here.
+      #
+      # This used to be the upstream hook at rev v0.8.0 while `make format` and
+      # `make lint` ran whatever `ruff>=0.8.0` resolved to — 0.14 — and the two
+      # format the same code differently. They took turns rewriting each other:
+      # formatting locally then committing made the hook revert those lines and
+      # abort, and a `ruff format` run reached files the author had not touched,
+      # dragging unrelated churn into feature branches. CI never noticed,
+      # because `make lint` checked lint rules and not formatting.
+      #
+      # One ruff, resolved from the lockfile, so there is no second version to
+      # remember to bump and nothing for it to disagree with. Same reasoning as
+      # the mypy hook below, which is `language: system` for its own reasons.
+      - id: ruff
+        name: ruff
+        language: system
+        entry: uv run ruff check --fix --exit-non-zero-on-fix
+        types: [python]
+
+      - id: ruff-format
+        name: ruff-format
+        language: system
+        entry: uv run ruff format
+        types: [python]
+
       - id: mypy
         name: mypy
         # Each package needs its own isolated MYPYPATH (see Makefile mypy target).

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ lint: $(PROTO_SENTINEL)
 	cd proto && buf lint
 	# Python Lint (Ruff)
 	PYTHONPATH=$(DNA_PATH):$(CORE_PATH):$(GATEWAY_PATH):$(TG_PATH):$(MCP_PATH):$(KEEPER_PATH) uv run ruff check .
+	# Formatting is checked, not merely applied by whoever ran `make format` last.
+	# Without this the repo does not verify the format it claims to enforce, and
+	# a file's formatting is whatever tool touched it most recently.
+	uv run ruff format --check .
 	# Python Type Check (Mypy)
 	# We use --explicit-package-bases to avoid double discovery when multiple paths overlap
 	MYPYPATH=$(CORE_PATH) uv run mypy --explicit-package-bases core/src

--- a/agents/bee-evolver/src/config.py
+++ b/agents/bee-evolver/src/config.py
@@ -40,8 +40,14 @@ class EvolverSettings(BaseSettings):
     # Filesystem scan: directories to exclude (comma-separated)
     exclude_dirs: list[str] = Field(
         default=[
-            ".git", ".venv", "node_modules", "__pycache__",
-            "gen-proto", "gen", ".mypy_cache", ".ruff_cache",
+            ".git",
+            ".venv",
+            "node_modules",
+            "__pycache__",
+            "gen-proto",
+            "gen",
+            ".mypy_cache",
+            ".ruff_cache",
         ],
         alias="EVOLVER_EXCLUDE_DIRS",
     )

--- a/agents/bee-evolver/src/hive/metabolism.py
+++ b/agents/bee-evolver/src/hive/metabolism.py
@@ -138,6 +138,7 @@ class EvolverMetabolism:
     def _configure_git(self) -> None:
         """Set git identity scoped to the current repository (not global)."""
         from .utils import find_hive_root
+
         root = str(find_hive_root())
         try:
             subprocess.run(  # nosec

--- a/agents/bee-evolver/src/hive/transformer/__init__.py
+++ b/agents/bee-evolver/src/hive/transformer/__init__.py
@@ -63,8 +63,7 @@ class EvolverTransformer:
                 logger.error("evolver_transformer_llm_failed", error=str(fe))
                 return EvolutionPlan(
                     narrative=(
-                        "The Evolver's brain is offline. "
-                        f"Primary: {e}. Fallback: {fe}"
+                        f"The Evolver's brain is offline. Primary: {e}. Fallback: {fe}"
                     ),
                     token_usage=0,
                     llm_failed=True,

--- a/agents/bee-evolver/tests/test_cycle_record.py
+++ b/agents/bee-evolver/tests/test_cycle_record.py
@@ -24,9 +24,7 @@ def _read_record(path):
 
 
 def _read_records(path):
-    return [
-        json.loads(x) for x in open(path, encoding="utf-8").read().splitlines()
-    ]
+    return [json.loads(x) for x in open(path, encoding="utf-8").read().splitlines()]
 
 
 async def test_transformer_failure_still_writes_a_record(tmp_path, monkeypatch):

--- a/core/src/aura_hive/hive/proteins/guard/skill.py
+++ b/core/src/aura_hive/hive/proteins/guard/skill.py
@@ -154,9 +154,9 @@ class GuardSkill(
 
     async def _validate_transaction(self, params: dict[str, Any]) -> Observation:
         assert self.provider is not None
-        assert (
-            self._registry is not None
-        ), "registry not injected — call inject_registry() first"
+        assert self._registry is not None, (
+            "registry not injected — call inject_registry() first"
+        )
         wallet_address = params.get("wallet_address", "")
         sanct_obs = await self._registry.execute(
             "persistence", "is_wallet_sanctified", {"wallet_address": wallet_address}
@@ -176,9 +176,9 @@ class GuardSkill(
 
     async def _validate_x402_payment(self, params: dict[str, Any]) -> Observation:
         assert self.provider is not None
-        assert (
-            self._registry is not None
-        ), "registry not injected — call inject_registry() first"
+        assert self._registry is not None, (
+            "registry not injected — call inject_registry() first"
+        )
         wallet_address = params.get("wallet_address", "")
         amount = float(params.get("amount", 0.0))
         sanct_obs = await self._registry.execute(

--- a/core/tests/test_rwa_stablehacks_flow.py
+++ b/core/tests/test_rwa_stablehacks_flow.py
@@ -255,18 +255,18 @@ async def test_rwa_stablehacks_flow_approved(metabolic_loop):
     assert observation.success is True, f"Metabolic loop failed: {observation.error}"
 
     meta = observation.metadata.to_dict()
-    assert (
-        meta.get("transaction_chain") == "SOLANA"
-    ), "Expected Solana as the transaction chain"
-    assert (
-        meta.get("transaction_type") == "RWA_VAULT_MINT"
-    ), "Expected RWA_VAULT_MINT transaction type"
-    assert (
-        meta.get("vault_id") == "vault-stablehacks-001"
-    ), "Expected vault ID from approved vault"
-    assert (
-        float(meta.get("collateral_amount", "0")) > 0
-    ), "Expected positive collateral amount"
+    assert meta.get("transaction_chain") == "SOLANA", (
+        "Expected Solana as the transaction chain"
+    )
+    assert meta.get("transaction_type") == "RWA_VAULT_MINT", (
+        "Expected RWA_VAULT_MINT transaction type"
+    )
+    assert meta.get("vault_id") == "vault-stablehacks-001", (
+        "Expected vault ID from approved vault"
+    )
+    assert float(meta.get("collateral_amount", "0")) > 0, (
+        "Expected positive collateral amount"
+    )
 
 
 @pytest.mark.asyncio
@@ -309,16 +309,16 @@ async def test_rwa_transformer_produces_solana_intent(rwa_transformer):
 
     params_name, params_value = betterproto.which_one_of(intent, "params")
     assert params_name == "rwa_vault", f"Expected 'rwa_vault', got '{params_name}'"
-    assert (
-        intent.action == ActionType.ACTION_TYPE_ACCEPT
-    ), f"Expected ActionType.ACTION_TYPE_ACCEPT for compliant RWA, got {intent.action}"
-    assert (
-        params_value.wallet_address == "SolanaVaultExample123"
-    ), "Expected Solana wallet address in vault intent"
+    assert intent.action == ActionType.ACTION_TYPE_ACCEPT, (
+        f"Expected ActionType.ACTION_TYPE_ACCEPT for compliant RWA, got {intent.action}"
+    )
+    assert params_value.wallet_address == "SolanaVaultExample123", (
+        "Expected Solana wallet address in vault intent"
+    )
     assert params_value.compliance.kyc_passed is True, "Expected KYC to pass"
-    assert (
-        params_value.compliance.compliance_status == "APPROVED"
-    ), "Expected compliance status APPROVED"
+    assert params_value.compliance.compliance_status == "APPROVED", (
+        "Expected compliance status APPROVED"
+    )
 
 
 @pytest.mark.asyncio
@@ -365,12 +365,12 @@ async def test_membrane_blocks_kyc_failure(rwa_membrane):
 
     result = await rwa_membrane.inspect_outbound(bad_intent, context)
 
-    assert (
-        result.action == ActionType.ACTION_TYPE_REJECT
-    ), "Membrane should reject KYC failure"
-    assert (
-        "MEMBRANE" in result.reasoning or "KYC" in result.reasoning
-    ), "Membrane should explain the block reason"
+    assert result.action == ActionType.ACTION_TYPE_REJECT, (
+        "Membrane should reject KYC failure"
+    )
+    assert "MEMBRANE" in result.reasoning or "KYC" in result.reasoning, (
+        "Membrane should explain the block reason"
+    )
 
 
 @pytest.mark.asyncio
@@ -428,9 +428,9 @@ async def test_rwa_kyc_rejected_path(mock_reasoning_skill, skill_registry):
 
     intent = await transformer.think(context)
 
-    assert (
-        intent.action == ActionType.ACTION_TYPE_REJECT
-    ), "KYC failure should result in REJECT"
+    assert intent.action == ActionType.ACTION_TYPE_REJECT, (
+        "KYC failure should result in REJECT"
+    )
 
     params_name, params_value = betterproto.which_one_of(intent, "params")
     assert params_name == "rwa_vault"
@@ -457,9 +457,9 @@ async def test_metabolic_loop_rejects_kyc_failure(
     observation = await metabolic_loop.execute(mock_signal)
 
     meta = observation.metadata.to_dict()
-    assert (
-        meta.get("transaction_chain") != "SOLANA" or not observation.success
-    ), "KYC/AML failure should not produce successful Solana transaction"
+    assert meta.get("transaction_chain") != "SOLANA" or not observation.success, (
+        "KYC/AML failure should not produce successful Solana transaction"
+    )
 
 
 if __name__ == "__main__":

--- a/core/tests/test_rwa_transformer.py
+++ b/core/tests/test_rwa_transformer.py
@@ -266,9 +266,9 @@ async def test_transformer_rwa_takes_priority_over_trade():
     intent = await transformer.think(context)
 
     params_name, _ = betterproto.which_one_of(intent, "params")
-    assert (
-        params_name == "rwa_vault"
-    ), f"RWA path should take priority over trade path, got '{params_name}'"
+    assert params_name == "rwa_vault", (
+        f"RWA path should take priority over trade path, got '{params_name}'"
+    )
     # Verify reasoning protein was called with 'rwa', not 'trade'
     # skill.execute(intent, params) — intent is the first positional arg
     call_args = mock_reasoning.execute.call_args


### PR DESCRIPTION
Closes #262.

## The problem

The pre-commit hook pinned ruff at `v0.8.0` while `make format` and `make lint` ran whatever `ruff>=0.8.0` resolved to — **0.14.14**. The two format the same code differently, so they took turns rewriting each other:

- format locally, then commit → the hook reverts those lines, reports "files were modified by this hook", and aborts;
- run `ruff format` at all → it reaches files you never touched, dragging unrelated churn into your branch.

That happened three times in one afternoon, on #258, #260 and #261, each time pulling two RWA test files into diffs that had nothing to do with them. Caught by reading `--stat` carefully every time, which is not a control.

**And CI never noticed.** `make lint` ran `ruff check` — lint rules only. Nothing anywhere checked formatting, so the repo did not verify the format it claims to enforce, and a file's formatting was whatever tool touched it most recently.

## The fix

Two commits, deliberately separate so the config diff is readable:

1. **`build:`** — the hook now runs the workspace ruff via `language: system`, the same way the mypy hook already runs the workspace mypy. There is no second version to remember to bump and nothing for it to disagree with. `make lint` also gains `ruff format --check .`.
2. **`style:`** — the seven files where the two versions disagreed.

## Demonstrated rather than asserted

**The old hook fought the fix.** Committing the reformat first, under the old config, produced this:

```
ruff-format..............................................................Failed
3 files reformatted, 4 files left unchanged
```

— the 0.8 hook reverting the 0.14 formatting, live. So the commits are ordered config-then-reformat, and the reformat then went through clean.

**The new check catches drift.** Dropped a badly formatted file into the tree:

```
Would reformat: tools/_drift_probe.py
1 file would be reformatted, 248 files already formatted
```

Removed again; `248 files already formatted`.

## Verification

```
make lint                            passes end to end, including the new check
core/tests/                          398 passed
agents/bee-evolver/tests/             22 passed
```

The reformat touches 7 files / ~50 lines and changes no behaviour — small enough that splitting it out is about readability rather than risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)