### PR TITLE
fix(evolver): accept the EVOLVER_EXCLUDE_DIRS format the comment promises

### DIFF
--- a/agents/bee-evolver/src/config.py
+++ b/agents/bee-evolver/src/config.py
@@ -1,4 +1,8 @@
-from pydantic import AliasChoices, Field
+import json
+from typing import Annotated
+
+from pydantic import AliasChoices, Field, field_validator
+from pydantic_settings import NoDecode
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -37,8 +41,8 @@ class EvolverSettings(BaseSettings):
     max_improvements: int = Field(3, alias="EVOLVER_MAX_IMPROVEMENTS")
     max_tokens: int = Field(2000, alias="AURA_BEE_EVOLVER__MAX_TOKENS")
 
-    # Filesystem scan: directories to exclude (comma-separated)
-    exclude_dirs: list[str] = Field(
+    # Filesystem scan: directories to exclude (comma-separated, or a JSON array)
+    exclude_dirs: Annotated[list[str], NoDecode] = Field(
         default=[
             ".git",
             ".venv",
@@ -53,6 +57,41 @@ class EvolverSettings(BaseSettings):
     )
     # GitHub Issues pagination limit
     issues_per_page: int = Field(20, alias="EVOLVER_ISSUES_PER_PAGE")
+
+    @field_validator("exclude_dirs", mode="before")
+    @classmethod
+    def _split_comma_separated(cls, value: object) -> object:
+        """
+        Accept `.git,.venv` as well as `[".git", ".venv"]`.
+
+        pydantic-settings JSON-decodes env values for a list field inside the
+        env source, *before* field validation — so the comma-separated form the
+        comment above promised failed at startup, and a validator alone would
+        never have seen the raw string. `NoDecode` on the annotation is what
+        hands it here intact. Nobody wants to write a JSON array in a shell for
+        a list of directory names.
+
+        Split here rather than at each use: the api-gateway spells its own
+        comma-separated settings as `str` and calls `.split(",")` wherever it
+        needs them, which duplicates the stripping and the empty-entry filter
+        across call sites. Doing it once at the boundary keeps the field typed
+        as what it is.
+
+        An empty string yields an empty list — a deliberate "exclude nothing",
+        distinct from the variable being unset, which keeps the defaults.
+        """
+        if not isinstance(value, str):
+            return value
+
+        text = value.strip()
+        # `NoDecode` means nothing decodes JSON for us any more, so anything
+        # already deployed with an array has to be handled here or it would
+        # break — the one format that used to work must keep working.
+        if text.startswith("["):
+            return json.loads(text)
+
+        return [part.strip() for part in text.split(",") if part.strip()]
+
     # Max chars of issue body passed to the LLM
     issue_body_limit: int = Field(500, alias="EVOLVER_ISSUE_BODY_LIMIT")
 

--- a/agents/bee-evolver/src/config.py
+++ b/agents/bee-evolver/src/config.py
@@ -87,8 +87,19 @@ class EvolverSettings(BaseSettings):
         # `NoDecode` means nothing decodes JSON for us any more, so anything
         # already deployed with an array has to be handled here or it would
         # break — the one format that used to work must keep working.
+        #
+        # Tried rather than assumed: `[` opens a JSON array and is also a legal
+        # first character for a directory name, so `[archived]` would otherwise
+        # crash startup — the failure this whole validator exists to remove,
+        # one branch over. Falling back is safe here because this is an
+        # *exclude* list: a misparsed entry names a directory that does not
+        # exist and excludes nothing, where refusing to start costs the
+        # deployment.
         if text.startswith("["):
-            return json.loads(text)
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                pass
 
         return [part.strip() for part in text.split(",") if part.strip()]
 

--- a/agents/bee-evolver/tests/test_config_lists.py
+++ b/agents/bee-evolver/tests/test_config_lists.py
@@ -90,3 +90,39 @@ class TestNothingElseBreaks:
 
         for expected in DEFAULTS:
             assert expected in settings.exclude_dirs
+
+
+class TestABracketIsNotAlwaysJson:
+    """
+    `[` starts a JSON array and is also a legal first character for a directory
+    name. Guessing by the bracket alone and calling `json.loads` on the result
+    turns `[archived]` into a crash at startup — the same failure this whole
+    change exists to remove, reintroduced one branch over.
+
+    Falling back to comma-splitting is safe here in a way it would not be
+    everywhere: this is an *exclude* list, so a misparsed entry names a
+    directory that does not exist and excludes nothing. Failing open costs a
+    wrong entry; failing closed costs the deployment.
+    """
+
+    def test_a_directory_named_like_an_array_is_not_json(self, clean_env: None) -> None:
+        assert with_value("[archived]") == ["[archived]"]
+
+    def test_such_a_name_inside_a_comma_separated_list(self, clean_env: None) -> None:
+        assert with_value("[archived],.git") == ["[archived]", ".git"]
+
+    def test_a_real_array_is_still_read_as_json(self, clean_env: None) -> None:
+        """The fallback must not swallow the format it is there to preserve."""
+        assert with_value('[".git", ".venv"]') == [".git", ".venv"]
+
+    def test_a_malformed_array_does_not_take_the_service_down(
+        self, clean_env: None
+    ) -> None:
+        """
+        Entries come out odd, and that is the right trade: they name
+        directories that do not exist, so nothing is excluded that should not
+        be. Refusing to start would be worse for a list of things to skip.
+        """
+        result = with_value('[".git", ".venv"')
+
+        assert isinstance(result, list)

--- a/agents/bee-evolver/tests/test_config_lists.py
+++ b/agents/bee-evolver/tests/test_config_lists.py
@@ -1,0 +1,92 @@
+"""
+`EVOLVER_EXCLUDE_DIRS` accepts what its comment promises.
+
+The field is `list[str]`, and pydantic-settings parses env values for those as
+JSON. The comment beside it said comma-separated, so an operator following it
+got a service that would not start — and an error naming JSON parsing rather
+than the comment that misled them.
+
+Comma-separated is the right format to accept for a list of directory names:
+nobody wants to write a JSON array in a shell, and every other comma-separated
+setting in this repo (the gateway's CORS and trusted-origin lists) is spelled
+that way too. Doing the split in a validator rather than at each use keeps the
+field properly typed and puts the parsing in one place.
+"""
+
+import os
+from collections.abc import Iterator
+
+import pytest
+from config import EvolverSettings
+
+DEFAULTS = [".git", ".venv", "node_modules", "__pycache__"]
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """
+    The variable under test removed, and the settings this model requires
+    supplied.
+
+    `EvolverSettings` declares two fields with no default — `llm__api_key` and
+    `github_repository` — so constructing it needs both from the environment.
+    Other modules in this directory set them at import time, which made an
+    earlier version of this file pass in a full run and fail on its own: green
+    only because of the order pytest happened to collect in. Supplied here so
+    these tests stand up alone.
+    """
+    monkeypatch.delenv("EVOLVER_EXCLUDE_DIRS", raising=False)
+    monkeypatch.setenv("AURA_LLM__API_KEY", "test-key")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "zaebee/aura")
+    yield
+
+
+def with_value(value: str) -> list[str]:
+    os.environ["EVOLVER_EXCLUDE_DIRS"] = value
+    try:
+        return EvolverSettings().exclude_dirs
+    finally:
+        os.environ.pop("EVOLVER_EXCLUDE_DIRS", None)
+
+
+class TestTheDocumentedFormatWorks:
+    def test_a_comma_separated_list_is_accepted(self, clean_env: None) -> None:
+        """The format the comment promised, which used to fail at startup."""
+        assert with_value(".git,.venv") == [".git", ".venv"]
+
+    def test_spaces_around_entries_are_trimmed(self, clean_env: None) -> None:
+        """`FOO=.git, .venv` is what a person writes; a leading space is not a name."""
+        assert with_value(".git, .venv , node_modules") == [
+            ".git",
+            ".venv",
+            "node_modules",
+        ]
+
+    def test_a_single_entry_needs_no_comma(self, clean_env: None) -> None:
+        assert with_value(".git") == [".git"]
+
+    def test_empty_entries_are_dropped(self, clean_env: None) -> None:
+        """A trailing comma is a typo, not a directory named ''."""
+        assert with_value(".git,,.venv,") == [".git", ".venv"]
+
+    def test_an_empty_value_excludes_nothing(self, clean_env: None) -> None:
+        """
+        Distinct from the variable being unset, which keeps the defaults.
+        Setting it to empty is a deliberate "scan everything".
+        """
+        assert with_value("") == []
+
+
+class TestNothingElseBreaks:
+    def test_the_json_form_still_works(self, clean_env: None) -> None:
+        """
+        Anything already deployed with a JSON array keeps working — the format
+        that used to be the only one accepted.
+        """
+        assert with_value('[".git", ".venv"]') == [".git", ".venv"]
+
+    def test_an_unset_variable_keeps_the_defaults(self, clean_env: None) -> None:
+        settings = EvolverSettings()
+
+        for expected in DEFAULTS:
+            assert expected in settings.exclude_dirs


### PR DESCRIPTION
Closes #267.

## The problem

```python
# Filesystem scan: directories to exclude (comma-separated)
exclude_dirs: list[str] = Field(default=[".git", ".venv", …], alias="EVOLVER_EXCLUDE_DIRS")
```

pydantic-settings parses env values for a list field as JSON, so the documented format fails at startup:

```
EVOLVER_EXCLUDE_DIRS=.git,.venv
SettingsError: error parsing value for field "exclude_dirs" from source "EnvSettingsSource"
```

An operator following the comment gets a service that will not start, and the error names JSON parsing rather than the comment that misled them.

Chose to honour the comment rather than rewrite it: nobody wants to write a JSON array in a shell for a list of directory names, and the api-gateway's own comma-separated settings read that way. Both formats parse now, so anything already deployed with an array keeps working.

## `field_validator` alone does nothing — worth knowing

This is the part I would not have predicted. pydantic-settings **JSON-decodes env values for a list field inside the env source, before field validation runs**, so a `mode="before"` validator never sees the raw string:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

The obvious fix silently does not work. `NoDecode` on the annotation is what hands the value over intact — and it also means the JSON branch has to be parsed here rather than inherited.

## Why a validator rather than the house style

The gateway spells its equivalents as `str` and calls `.split(",")` wherever it needs them — `security.py:215` and `main.py:57`, each repeating the strip and the empty-entry filter. Doing it once at the boundary keeps the field typed as what it is. Worth unifying, but not from this branch.

(`SafetySettings.allowed_addons` is also `list[str]`, but promises nothing in a comment and is never set from env — no false advertising there, so left alone.)

## The tests needed two rounds of their own

**They first passed in a full run and failed alone.** `EvolverSettings` has two fields with no default, other modules in that directory set them at import time, and my fixture was quietly relying on it — green because of the order pytest happened to collect in.

The fixture supplies them itself now, and the file was checked three ways: alone, in the full directory, and mixed with another module.

I also stripped `NoDecode` once more afterwards to confirm the tests still catch its absence — five of the seven fail without it. Changing how a test sets up its environment can disarm it, so that check is not optional.

```
agents/bee-evolver/tests/    29 passed  (7 new)
make lint                    passes end to end
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)