### PR TITLE
fix(guard): say when a check could not be performed, not that it failed

### DIFF
--- a/core/src/aura_hive/hive/proteins/guard/skill.py
+++ b/core/src/aura_hive/hive/proteins/guard/skill.py
@@ -91,30 +91,39 @@ class GuardSkill(
             # recovered by searching the message for "margin" or "floor", which
             # relabelled the audit trail on any rewording and already misfiled
             # the fail-closed branch as a margin violation.
-            err_msg = str(e)
-            code = e.code
-
             assert self.provider is not None
-            # `or {}` rather than a default: a caller that passed an explicit
-            # None gets the same treatment as one that passed nothing. This runs
-            # inside the SafetyViolation handler, a sibling of the generic
-            # `except Exception` below rather than nested in it, so a raise here
-            # escapes the skill entirely.
-            safe_p = self.provider.calculate_safe_price(
-                params.get("context") or {}, code
-            )
+
+            # A violation from `validate_decision` carries the derivation that
+            # produced it; nothing else does. That is the signal for whether the
+            # negotiation-shaped extras apply.
+            #
+            # They do not apply to a wallet check. There is no safe price for
+            # "we could not establish whether this wallet is sanctified", and a
+            # consumer reading `safe_price: 0.0` could act on it; and citing the
+            # negotiation rule set would claim an audit trail for a decision it
+            # never judged. Report the code and the message, and nothing the
+            # surrounding shape merely expects.
+            report = {"error_code": e.code}
+
+            if e.derivation is not None:
+                # `or {}` rather than a default: a caller that passed an
+                # explicit None gets the same treatment as one that passed
+                # nothing. This runs inside the SafetyViolation handler, a
+                # sibling of the generic `except Exception` below rather than
+                # nested in it, so a raise here escapes the skill entirely.
+                report["safe_price"] = str(
+                    self.provider.calculate_safe_price(
+                        params.get("context") or {}, e.code
+                    )
+                )
+                report.update(
+                    _derivation_fields(
+                        e.derivation, self.provider.ruleset.version_string
+                    )
+                )
+
             return Observation(
-                success=False,
-                error=err_msg,
-                metadata=make_struct(
-                    {
-                        "error_code": code,
-                        "safe_price": str(safe_p),
-                        **_derivation_fields(
-                            e.derivation, self.provider.ruleset.version_string
-                        ),
-                    }
-                ),
+                success=False, error=str(e), metadata=make_struct(report)
             )
         except Exception as e:
             logger.error(f"Guard skill error: {e}")
@@ -152,16 +161,49 @@ class GuardSkill(
         self.provider.validate_vision(p.vision_result)
         return Observation(success=True)
 
+    async def _wallet_is_sanctified(self, wallet_address: str) -> bool:
+        """
+        Ask persistence whether a wallet is sanctified.
+
+        Raises when the question could not be answered, rather than returning
+        False. Both outcomes refuse — a wallet whose sanctification cannot be
+        established must not transact — but they refuse for different reasons,
+        and reporting a lookup failure as "not sanctified" sends an operator to
+        look at the wallet when the fault is that persistence is down.
+
+        This is the distinction the receipt work drew between `ok` and
+        `attested`: nothing was wrong versus something was established. Both
+        call sites go through here so the same fault cannot produce two
+        different stories from one protein.
+        """
+        assert self._registry is not None, (
+            "registry not injected — call inject_registry() first"
+        )
+        observation = await self._registry.execute(
+            "persistence", "is_wallet_sanctified", {"wallet_address": wallet_address}
+        )
+
+        if not observation.success:
+            logger.error(
+                "sanctification_lookup_failed wallet=%s error=%s",
+                wallet_address,
+                observation.error,
+            )
+            raise SafetyViolation(
+                f"Could not establish whether wallet {wallet_address!r} is "
+                f"sanctified: {observation.error}",
+                code="SANCTIFICATION_UNAVAILABLE",
+            )
+
+        return bool(observation.metadata.to_dict().get("sanctified", False))
+
     async def _validate_transaction(self, params: dict[str, Any]) -> Observation:
         assert self.provider is not None
         assert self._registry is not None, (
             "registry not injected — call inject_registry() first"
         )
         wallet_address = params.get("wallet_address", "")
-        sanct_obs = await self._registry.execute(
-            "persistence", "is_wallet_sanctified", {"wallet_address": wallet_address}
-        )
-        is_sanctified = bool(sanct_obs.metadata.to_dict().get("sanctified", False))
+        is_sanctified = await self._wallet_is_sanctified(wallet_address)
         safe_price = self.provider.validate_transaction(
             wallet_address=wallet_address,
             llm_price=params.get("llm_price", 0.0),
@@ -181,20 +223,7 @@ class GuardSkill(
         )
         wallet_address = params.get("wallet_address", "")
         amount = float(params.get("amount", 0.0))
-        sanct_obs = await self._registry.execute(
-            "persistence", "is_wallet_sanctified", {"wallet_address": wallet_address}
-        )
-        if not sanct_obs.success:
-            logger.error(
-                "x402_wallet_verification_failed wallet=%s error=%s",
-                wallet_address,
-                sanct_obs.error,
-            )
-            return Observation(
-                success=False,
-                error=f"Wallet verification failed: {sanct_obs.error}",
-            )
-        is_sanctified = bool(sanct_obs.metadata.to_dict().get("sanctified", False))
+        is_sanctified = await self._wallet_is_sanctified(wallet_address)
         self.provider.validate_x402_payment(
             wallet_address=wallet_address,
             amount=amount,

--- a/core/src/aura_hive/hive/proteins/guard/skill.py
+++ b/core/src/aura_hive/hive/proteins/guard/skill.py
@@ -1,6 +1,6 @@
-import logging
 from typing import Any
 
+import structlog
 from aura_core import SkillProtocol, SkillRegistry, make_struct
 from aura_core_gen.aura.core.v1 import Observation
 
@@ -9,7 +9,7 @@ from aura_hive.config.policy import SafetySettings
 from .engine import Derivation, OutputGuard, SafetyViolation
 from .schema import SafePriceParams, ValidationParams, VisionValidationParams
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def _derivation_fields(
@@ -126,7 +126,7 @@ class GuardSkill(
                 success=False, error=str(e), metadata=make_struct(report)
             )
         except Exception as e:
-            logger.error(f"Guard skill error: {e}")
+            logger.error("guard_skill_error", intent=intent, error=str(e))
             return Observation(success=False, error=str(e))
 
     async def _validate_decision(self, params: dict[str, Any]) -> Observation:
@@ -185,9 +185,9 @@ class GuardSkill(
 
         if not observation.success:
             logger.error(
-                "sanctification_lookup_failed wallet=%s error=%s",
-                wallet_address,
-                observation.error,
+                "sanctification_lookup_failed",
+                wallet=wallet_address,
+                error=observation.error,
             )
             raise SafetyViolation(
                 f"Could not establish whether wallet {wallet_address!r} is "

--- a/core/tests/test_guard_lookup_failure.py
+++ b/core/tests/test_guard_lookup_failure.py
@@ -1,0 +1,228 @@
+"""
+"The check could not be performed" is not "the check was performed and refused".
+
+Both refuse, and both should — a wallet whose sanctification cannot be
+established must not transact. But they refuse for different reasons, and the
+guard used to report them the same way on one path and differently on the other:
+`_validate_transaction` treated a failed lookup as an unsanctified wallet, while
+`_validate_x402_payment` twenty lines below returned a descriptive error.
+
+An operator reading "wallet is not sanctified" goes and looks at the wallet.
+When the fault is that persistence is down, that is a wrong-turn of a diagnosis
+handed out by the component best placed to know better.
+
+This is the distinction the receipt work drew between `ok` and `attested`:
+nothing was wrong versus someone established something. The guard now answers it
+the same way in both places.
+"""
+
+from typing import Any
+
+import pytest
+from aura_core import SkillRegistry
+from aura_core.struct_utils import make_struct
+from aura_core_gen.aura.core.v1 import Observation
+from aura_hive.hive.proteins.guard import GuardSkill
+from aura_hive.hive.proteins.guard.engine import OutputGuard
+
+
+class _Safety:
+    min_profit_margin = 0.10
+    max_x402_payment = 5.0
+
+
+class _Persistence:
+    """Stands in for the protein that answers sanctification questions."""
+
+    def __init__(self, observation: Observation) -> None:
+        self._observation = observation
+
+    def get_name(self) -> str:
+        return "persistence"
+
+    async def execute(self, intent: str, params: dict[str, Any]) -> Observation:
+        return self._observation
+
+
+def guard_talking_to(observation: Observation) -> GuardSkill:
+    registry = SkillRegistry()
+    registry.register("persistence", _Persistence(observation))
+    guard = GuardSkill()
+    guard.bind(_Safety(), OutputGuard(safety_settings=_Safety()))
+    guard.inject_registry(registry)
+    return guard
+
+
+LOOKUP_FAILED = Observation(success=False, error="connection refused")
+NOT_SANCTIFIED = Observation(success=True, metadata=make_struct({"sanctified": False}))
+SANCTIFIED = Observation(success=True, metadata=make_struct({"sanctified": True}))
+
+TRANSACTION = {
+    "wallet_address": "0xabc",
+    "llm_price": 100.0,
+    "bid": 90.0,
+    "base_price": 100.0,
+}
+PAYMENT = {"wallet_address": "0xabc", "amount": 1.0}
+
+
+def code_of(observation: Observation) -> str:
+    return str(observation.metadata.to_dict().get("error_code", ""))
+
+
+class TestAFailedLookupSaysSo:
+    @pytest.mark.asyncio
+    async def test_a_transaction_does_not_blame_the_wallet(self) -> None:
+        obs = await guard_talking_to(LOOKUP_FAILED).execute(
+            "validate_transaction", TRANSACTION
+        )
+
+        assert obs.success is False
+        assert code_of(obs) == "SANCTIFICATION_UNAVAILABLE"
+
+    @pytest.mark.asyncio
+    async def test_a_payment_does_not_either(self) -> None:
+        obs = await guard_talking_to(LOOKUP_FAILED).execute(
+            "validate_x402_payment", PAYMENT
+        )
+
+        assert obs.success is False
+        assert code_of(obs) == "SANCTIFICATION_UNAVAILABLE"
+
+    @pytest.mark.asyncio
+    async def test_both_paths_report_it_identically(self) -> None:
+        """
+        The point of the change. The same underlying fault reaching two
+        capabilities of one protein should not produce two different stories.
+        """
+        transaction = await guard_talking_to(LOOKUP_FAILED).execute(
+            "validate_transaction", TRANSACTION
+        )
+        payment = await guard_talking_to(LOOKUP_FAILED).execute(
+            "validate_x402_payment", PAYMENT
+        )
+
+        assert code_of(transaction) == code_of(payment)
+
+    @pytest.mark.asyncio
+    async def test_the_underlying_error_is_not_swallowed(self) -> None:
+        """An operator needs the cause, not only that there was one."""
+        obs = await guard_talking_to(LOOKUP_FAILED).execute(
+            "validate_transaction", TRANSACTION
+        )
+
+        assert "connection refused" in obs.error
+
+
+class TestARefusalStillReadsAsARefusal:
+    @pytest.mark.asyncio
+    async def test_an_unsanctified_wallet_is_still_named_as_such(self) -> None:
+        """
+        The distinction cuts both ways: a wallet that really is unsanctified
+        must not be reported as an outage.
+        """
+        obs = await guard_talking_to(NOT_SANCTIFIED).execute(
+            "validate_transaction", TRANSACTION
+        )
+
+        assert obs.success is False
+        assert code_of(obs) != "SANCTIFICATION_UNAVAILABLE"
+        assert "sanctified" in obs.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_a_payment_from_an_unsanctified_wallet_too(self) -> None:
+        obs = await guard_talking_to(NOT_SANCTIFIED).execute(
+            "validate_x402_payment", PAYMENT
+        )
+
+        assert obs.success is False
+        assert code_of(obs) != "SANCTIFICATION_UNAVAILABLE"
+
+
+class TestNothingGetsThrough:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("capability", "params"),
+        [("validate_transaction", TRANSACTION), ("validate_x402_payment", PAYMENT)],
+    )
+    async def test_a_failed_lookup_still_fails_closed(
+        self, capability: str, params: dict[str, Any]
+    ) -> None:
+        """
+        Naming the fault better must not soften it. A wallet whose
+        sanctification cannot be established does not transact.
+        """
+        obs = await guard_talking_to(LOOKUP_FAILED).execute(capability, params)
+
+        assert obs.success is False
+
+    @pytest.mark.asyncio
+    async def test_a_sanctified_wallet_still_passes(self) -> None:
+        obs = await guard_talking_to(SANCTIFIED).execute(
+            "validate_transaction", TRANSACTION
+        )
+
+        assert obs.success is True
+
+
+class TestTheReportClaimsOnlyWhatApplies:
+    """
+    `execute` renders every SafetyViolation the same way, and that way was
+    shaped for negotiation decisions: a substitute price and the version of the
+    rule set that judged them.
+
+    Neither applies to a wallet lookup. There is no safe price for "we could not
+    check", and a consumer reading `safe_price: 0.0` could act on it; and the
+    negotiation rule set did not judge this, so citing its version claims an
+    audit trail that does not exist. Same rule as everywhere else in this
+    series — say what happened, not what the surrounding shape expects.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_lookup_failure_proposes_no_price(self) -> None:
+        obs = await guard_talking_to(LOOKUP_FAILED).execute(
+            "validate_transaction", TRANSACTION
+        )
+
+        assert "safe_price" not in obs.metadata.to_dict()
+
+    @pytest.mark.asyncio
+    async def test_it_does_not_cite_a_rule_set_that_did_not_judge_it(self) -> None:
+        obs = await guard_talking_to(LOOKUP_FAILED).execute(
+            "validate_transaction", TRANSACTION
+        )
+
+        assert "ruleset_version" not in obs.metadata.to_dict()
+
+    @pytest.mark.asyncio
+    async def test_an_unsanctified_wallet_reports_the_same_way(self) -> None:
+        """Not specific to the lookup failing — no wallet check is a negotiation."""
+        obs = await guard_talking_to(NOT_SANCTIFIED).execute(
+            "validate_x402_payment", PAYMENT
+        )
+
+        assert "safe_price" not in obs.metadata.to_dict()
+
+    @pytest.mark.asyncio
+    async def test_a_negotiation_refusal_still_carries_both(self) -> None:
+        """
+        The other half: a decision the rule set really did judge keeps its
+        substitute price and its rule-set version. Trimming those would lose
+        what the Membrane needs to build a receipt.
+        """
+        guard = guard_talking_to(SANCTIFIED)
+
+        obs = await guard.execute(
+            "validate_decision",
+            {
+                "decision": {"action": "counter", "price": 500.0},
+                "context": {"floor_price": 1000.0, "internal_cost": 500.0},
+            },
+        )
+        meta = obs.metadata.to_dict()
+
+        assert obs.success is False
+        assert meta["error_code"] == "FLOOR_PRICE_VIOLATION"
+        assert float(meta["safe_price"]) > 0
+        assert meta["ruleset_version"].startswith("guard/negotiation@")
+        assert meta["derivation_hash"] != ""


### PR DESCRIPTION
Closes #269.

## The inconsistency

Two capabilities of one protein made the same sanctification lookup and handled its failure differently:

- `_validate_transaction` — treated a failed lookup as an unsanctified wallet;
- `_validate_x402_payment`, twenty lines below — returned a descriptive error.

Both refuse, and both should: a wallet whose sanctification cannot be established must not transact. **That is unchanged.** But they refuse for *different reasons*, and the same underlying fault produced two different stories.

An operator reading "wallet is not sanctified" goes and looks at the wallet. When the fault is that persistence is down, that is a wrong turn handed out by the component best placed to know better.

Both call sites now go through one lookup that raises `SANCTIFICATION_UNAVAILABLE` when the question could not be answered, and carries the underlying error rather than swallowing it.

## Which surfaced two more claims the report had no business making

Every `SafetyViolation` was rendered in a shape built for negotiation decisions. A failed wallet lookup came back as:

```python
{'error_code': 'SANCTIFICATION_UNAVAILABLE',
 'safe_price': '0.0',                                    # ← proposing nothing of the sort
 'ruleset_version': 'guard/negotiation@1.0.0+46cc...'}   # ← judged no such thing
```

There is no safe price for "we could not check", and a consumer reading `safe_price: 0.0` could act on it. Citing the negotiation rule set claims an audit trail for a decision it never judged.

The derivation on the exception is the signal — violations from `validate_decision` carry one, nothing else does — so the negotiation-shaped extras now travel only where they mean something. A negotiation refusal keeps its substitute price, rule-set version and derivation; verified end-to-end that the Membrane still mints a complete receipt.

## Same rule as the rest of the series

Claim what happened, not what the surrounding shape expects. It is the distinction the receipt drew between `ok` and `attested`, one layer down.

## Testing

`core/tests/test_guard_lookup_failure.py`, 13 tests across four properties: a failed lookup says so, a refusal still reads as a refusal, nothing gets through either way, and the report carries only what applies.

```
core/tests/                          426 passed  (was 413)
make lint                            passes end to end
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)