### PR TITLE
fix(tests): close the files these helpers open

### DIFF
--- a/agents/bee-evolver/pyproject.toml
+++ b/agents/bee-evolver/pyproject.toml
@@ -37,3 +37,19 @@ dev = [
 pythonpath = ["src"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
+# An unclosed file is a test failure here, not a warning nobody reads.
+#
+# These suites read their fixtures with bare `open(...)`, which CPython's
+# refcounting closed promptly enough that nothing ever noticed — a correctness
+# that rests on an implementation detail rather than on the language. Both
+# suites are clean, so this costs nothing today and catches the next one.
+filterwarnings = [
+    "error::ResourceWarning",
+    # The one that actually bites. A ResourceWarning is raised during garbage
+    # collection, where an exception cannot propagate, so pytest converts it
+    # into this instead — and erroring on ResourceWarning alone leaves the run
+    # green with a warning nobody reads. Verified by reintroducing a bare
+    # `open(...)` and watching it fail.
+    "error::pytest.PytestUnraisableExceptionWarning",
+]

--- a/agents/bee-evolver/tests/test_cycle_record.py
+++ b/agents/bee-evolver/tests/test_cycle_record.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -18,13 +19,13 @@ def _settings(tmp_path) -> EvolverSettings:
 
 
 def _read_record(path):
-    lines = open(path, encoding="utf-8").read().splitlines()
+    lines = Path(path).read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     return json.loads(lines[0])
 
 
 def _read_records(path):
-    return [json.loads(x) for x in open(path, encoding="utf-8").read().splitlines()]
+    return [json.loads(x) for x in Path(path).read_text(encoding="utf-8").splitlines()]
 
 
 async def test_transformer_failure_still_writes_a_record(tmp_path, monkeypatch):

--- a/agents/bee-evolver/tests/test_metabolism_writer.py
+++ b/agents/bee-evolver/tests/test_metabolism_writer.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from config import EvolverSettings
 from hive.connector import EvolverConnector
@@ -39,7 +40,7 @@ def test_writer_appends_and_creates_parent_dir(tmp_path):
     connector.write_metabolic_record(_record("cycle-1"))
     connector.write_metabolic_record(_record("cycle-2"))
 
-    lines = open(settings.metabolism_log, encoding="utf-8").read().splitlines()
+    lines = Path(settings.metabolism_log).read_text(encoding="utf-8").splitlines()
     assert len(lines) == 2
     assert json.loads(lines[0])["cycle_id"] == "cycle-1"
     assert json.loads(lines[1])["cycle_id"] == "cycle-2"

--- a/agents/bee-keeper/pyproject.toml
+++ b/agents/bee-keeper/pyproject.toml
@@ -55,3 +55,19 @@ dev = [
 pythonpath = ["src"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
+# An unclosed file is a test failure here, not a warning nobody reads.
+#
+# These suites read their fixtures with bare `open(...)`, which CPython's
+# refcounting closed promptly enough that nothing ever noticed — a correctness
+# that rests on an implementation detail rather than on the language. Both
+# suites are clean, so this costs nothing today and catches the next one.
+filterwarnings = [
+    "error::ResourceWarning",
+    # The one that actually bites. A ResourceWarning is raised during garbage
+    # collection, where an exception cannot propagate, so pytest converts it
+    # into this instead — and erroring on ResourceWarning alone leaves the run
+    # green with a warning nobody reads. Verified by reintroducing a bare
+    # `open(...)` and watching it fail.
+    "error::pytest.PytestUnraisableExceptionWarning",
+]

--- a/agents/bee-keeper/tests/test_cycle_record.py
+++ b/agents/bee-keeper/tests/test_cycle_record.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 from aura_keeper.config import KeeperSettings
@@ -78,6 +79,6 @@ def test_cycle_writes_a_record(tmp_path):
         )
     )
 
-    record = json.loads(open(settings.metabolism_log, encoding="utf-8").read())
+    record = json.loads(Path(settings.metabolism_log).read_text(encoding="utf-8"))
     assert record["bee"] == "keeper"
     assert record["git_sha"] == "abc1234"


### PR DESCRIPTION
Closes #268.

## Four sites, not two

The issue named two helpers in `bee-evolver/tests/test_cycle_record.py`. A sweep found the same pattern in `test_metabolism_writer.py` and in **bee-keeper's** own `test_cycle_record.py`. Fixing two of four would have read as a decision rather than an oversight.

`Path.read_text()` is shorter than a bare `open(...).read()` and closes by construction. Nothing was ever felt — CPython's refcounting closes these promptly — which is a correctness resting on an implementation detail rather than on the language.

## The guard needed two attempts, and the first was decoration

Since everything is clean under `-W error::ResourceWarning`, a `filterwarnings` entry costs nothing today and catches the next one. So I added it, then checked whether it actually bites — by reintroducing a bare `open(...)`:

```
33 passed, 3 warnings
```

**It does not.** A `ResourceWarning` is raised during garbage collection, where an exception cannot propagate, so pytest converts it into `PytestUnraisableExceptionWarning` and the run stays green with a warning nobody reads. Erroring on `ResourceWarning` alone is exactly the ornamental check I have spent this session removing elsewhere.

Erroring on both makes it real:

```
with the leak restored:  3 failed, 30 passed
without it:              33 passed
```

## Scope of the guard

Added only to the two packages that already carry `[tool.pytest.ini_options]`, which is where the leak lived. A repo-wide filter would need a root config section that does not exist, and I have not verified how pytest resolves config across this workspace — not something to guess at in a cleanup PR.

```
agents/bee-evolver/tests/    33 passed, 0 warnings
agents/bee-keeper/tests/      7 passed (11 pre-existing dspy DeprecationWarnings)
make lint                     passes end to end
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)