### PR TITLE
feat(persistence): make receipts outlive the log they were stored in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,3 +203,7 @@ tools-buyer:
 verify-receipts:
 	# Check the receipts a running Hive left in its log (LOG=path, or stdin when unset)
 	PYTHONPATH=$(TOOL_PATH):. uv run python tools/verify_receipts.py $(LOG)
+
+resolve-dispute:
+	# Resolve a dispute token into the receipt it names (TOKEN=<uuid>)
+	PYTHONPATH=$(TOOL_PATH):$(CORE_PATH) uv run python tools/resolve_dispute.py $(TOKEN)

--- a/core/src/aura_hive/hive/connector/main.py
+++ b/core/src/aura_hive/hive/connector/main.py
@@ -88,7 +88,15 @@ class HiveConnector(BaseConnector):
         timeout is what makes the promise above true for the failure mode that
         is likelier in production than the one it was written against.
         """
-        if not action.receipt or not action.dispute_token:
+        # Read defensively, because this guard sits outside the try below and
+        # `act` is declared `(action: Any, ...)`. Reaching straight for
+        # `action.receipt` meant anything that was not an Intent raised an
+        # AttributeError past every piece of fail-open handling and took the
+        # decision with it. No caller does that today; the promise is that it
+        # would not matter if one did.
+        receipt = getattr(action, "receipt", None)
+        dispute_token = getattr(action, "dispute_token", None)
+        if not receipt or not dispute_token:
             return
 
         # One log site, two ways to get there. A reported failure and a raised
@@ -102,8 +110,8 @@ class HiveConnector(BaseConnector):
                     "persistence",
                     "record_receipt",
                     {
-                        "receipt": action.receipt.to_dict(),
-                        "dispute_token": action.dispute_token,
+                        "receipt": receipt.to_dict(),
+                        "dispute_token": dispute_token,
                     },
                 ),
                 timeout=_ARCHIVE_TIMEOUT_SECONDS,
@@ -118,7 +126,7 @@ class HiveConnector(BaseConnector):
         if error:
             logger.warning(
                 "receipt_record_failed",
-                dispute_token=action.dispute_token,
+                dispute_token=dispute_token,
                 error=error,
             )
 

--- a/core/src/aura_hive/hive/connector/main.py
+++ b/core/src/aura_hive/hive/connector/main.py
@@ -46,6 +46,59 @@ class HiveConnector(BaseConnector):
         self.market_service = market_service
         self.settings = settings
 
+    async def act(self, action: Any, context: Any) -> Observation:
+        """
+        Archive the receipt, then act.
+
+        Written here rather than in the Membrane that mints it: this is the
+        step that performs I/O, and putting a Postgres round-trip inside a
+        boundary check would pay negotiation latency for an archive. The
+        Genome's `act` dispatches steps or falls back to `_handle_legacy`, and
+        recording before that delegation means every decision is archived on
+        both paths — including the refusals, which are the disputes most
+        likely to arrive.
+
+        `Any` rather than `Intent`/`Context` because the Genome declares it
+        that way; narrowing here is a Liskov violation mypy refuses.
+        """
+        await self._record_receipt(action)
+        return await super().act(action, context)
+
+    async def _record_receipt(self, action: Intent) -> None:
+        """
+        Fail-open, deliberately and completely.
+
+        The rule the receipt log line already follows: reporting on a decision
+        must never take that decision down. The cost is that archive holes are
+        possible and silent, which is why the failure is its own event — an
+        archive that sometimes never arrives is worse than one that expires,
+        because nothing announces it.
+        """
+        if not action.receipt or not action.dispute_token:
+            return
+
+        try:
+            observation = await self.registry.execute(
+                "persistence",
+                "record_receipt",
+                {
+                    "receipt": action.receipt.to_dict(),
+                    "dispute_token": action.dispute_token,
+                },
+            )
+            if not observation.success:
+                logger.warning(
+                    "receipt_record_failed",
+                    dispute_token=action.dispute_token,
+                    error=observation.error,
+                )
+        except Exception as e:
+            logger.warning(
+                "receipt_record_failed",
+                dispute_token=action.dispute_token,
+                error=str(e),
+            )
+
     async def _handle_legacy(self, action: Intent, context: Context) -> Observation:
         """
         Handle Intents that do not have steps.

--- a/core/src/aura_hive/hive/connector/main.py
+++ b/core/src/aura_hive/hive/connector/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 import uuid
 from typing import Any, cast
@@ -21,6 +22,11 @@ from aura_core_gen.aura.core.v1 import (
 )
 
 logger = structlog.get_logger(__name__)
+
+# How long the archive write may hold up a decision before it is abandoned.
+# Generous for a single indexed insert and short enough that a hung database
+# costs a negotiation latency rather than a negotiation.
+_ARCHIVE_TIMEOUT_SECONDS = 2.0
 
 
 def _get_hive(context: Context) -> Any:
@@ -73,6 +79,14 @@ class HiveConnector(BaseConnector):
         possible and silent, which is why the failure is its own event — an
         archive that sometimes never arrives is worse than one that expires,
         because nothing announces it.
+
+        Bounded, because "fail-open" against exceptions is only half of it. A
+        refused connection raises and lands here in milliseconds; a blackholed
+        one does not raise at all, and psycopg2 would sit in the kernel's TCP
+        retry for minutes — serially, ahead of the decision, on every call
+        including the refusals, which did no database work before this. The
+        timeout is what makes the promise above true for the failure mode that
+        is likelier in production than the one it was written against.
         """
         if not action.receipt or not action.dispute_token:
             return
@@ -83,16 +97,21 @@ class HiveConnector(BaseConnector):
         # adds a field to one of them.
         error: str | None = None
         try:
-            observation = await self.registry.execute(
-                "persistence",
-                "record_receipt",
-                {
-                    "receipt": action.receipt.to_dict(),
-                    "dispute_token": action.dispute_token,
-                },
+            observation = await asyncio.wait_for(
+                self.registry.execute(
+                    "persistence",
+                    "record_receipt",
+                    {
+                        "receipt": action.receipt.to_dict(),
+                        "dispute_token": action.dispute_token,
+                    },
+                ),
+                timeout=_ARCHIVE_TIMEOUT_SECONDS,
             )
             if not observation.success:
                 error = observation.error
+        except TimeoutError:
+            error = f"archive write exceeded {_ARCHIVE_TIMEOUT_SECONDS}s"
         except Exception as e:
             error = str(e)
 

--- a/core/src/aura_hive/hive/connector/main.py
+++ b/core/src/aura_hive/hive/connector/main.py
@@ -77,6 +77,11 @@ class HiveConnector(BaseConnector):
         if not action.receipt or not action.dispute_token:
             return
 
+        # One log site, two ways to get there. A reported failure and a raised
+        # one are the same event to whoever is watching for archive holes, and
+        # two `logger.warning` calls of the same shape drift the moment someone
+        # adds a field to one of them.
+        error: str | None = None
         try:
             observation = await self.registry.execute(
                 "persistence",
@@ -87,16 +92,15 @@ class HiveConnector(BaseConnector):
                 },
             )
             if not observation.success:
-                logger.warning(
-                    "receipt_record_failed",
-                    dispute_token=action.dispute_token,
-                    error=observation.error,
-                )
+                error = observation.error
         except Exception as e:
+            error = str(e)
+
+        if error:
             logger.warning(
                 "receipt_record_failed",
                 dispute_token=action.dispute_token,
-                error=str(e),
+                error=error,
             )
 
     async def _handle_legacy(self, action: Intent, context: Context) -> Observation:

--- a/core/src/aura_hive/hive/proteins/persistence/engine.py
+++ b/core/src/aura_hive/hive/proteins/persistence/engine.py
@@ -116,6 +116,46 @@ class MetabolicCost(Base):
     )
 
 
+class DecisionReceiptRecord(Base):
+    """
+    The auditor's copy of a decision receipt.
+
+    The log line was the only store, and it lives in a Loki with a short
+    retention — so a dispute arriving a month after the decision found nothing.
+    This table is what makes the corpus outlive the stream; the log line stays
+    as a second, independent path.
+
+    Nothing here is a price or a premise. Every receipt field is a digest, an
+    identifier, an enum, a timestamp or signature metadata, which is why the
+    whole document can be stored without becoming a new place the floor lives.
+    """
+
+    __tablename__ = "decision_receipts"
+
+    id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    # What the counterparty cites. The lookup key.
+    dispute_token: Mapped[str] = mapped_column(
+        String, nullable=False, unique=True, index=True
+    )
+    # What the signature binds — the auditor's other way in.
+    decision_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    # The session, for reassembling a whole negotiation.
+    request_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    # The receipt's own timestamp, kept as the string it carries rather than
+    # parsed into a DateTime, so the column holds what was signed instead of a
+    # reconstruction of it.
+    issued_at: Mapped[str] = mapped_column(String, nullable=False)
+    # The whole document, exactly as the log line carries it.
+    receipt: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    # When the row was written — deliberately separate from `issued_at`, so a
+    # divergence between deciding and recording is visible rather than hidden.
+    recorded_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(UTC)
+    )
+
+
 logger = structlog.get_logger(__name__)
 
 

--- a/core/src/aura_hive/hive/proteins/persistence/receipts.py
+++ b/core/src/aura_hive/hive/proteins/persistence/receipts.py
@@ -1,0 +1,50 @@
+"""ReceiptRepository — the auditor's copy of every decision receipt.
+
+Keeps the receipt SQL in one place so the skill's handlers stay thin
+(params -> repo -> Observation). Methods are synchronous; callers wrap them in
+``asyncio.to_thread`` exactly as the other repositories are called.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from .engine import DecisionReceiptRecord
+
+
+class ReceiptRepository:
+    """Write-once storage for decision receipts, read by dispute token."""
+
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        self._session = session_factory
+
+    def record(self, receipt: dict[str, Any], dispute_token: str) -> None:
+        """
+        Store a receipt under the token the counterparty was given.
+
+        The indexed columns are derived from the document rather than passed
+        in beside it, so an index cannot come to disagree with the receipt it
+        indexes.
+        """
+        with self._session() as session:
+            session.add(
+                DecisionReceiptRecord(
+                    dispute_token=dispute_token,
+                    decision_id=str(receipt.get("decisionId", "")),
+                    request_id=str(receipt.get("requestId", "")),
+                    issued_at=str(receipt.get("issuedAt", "")),
+                    receipt=receipt,
+                )
+            )
+            session.commit()
+
+    def find_by_dispute_token(self, token: str) -> dict[str, Any] | None:
+        """The document, or None. An unissued token is an answer, not a fault."""
+        with self._session() as session:
+            row = (
+                session.query(DecisionReceiptRecord)
+                .filter_by(dispute_token=token)
+                .first()
+            )
+            return dict(row.receipt) if row else None

--- a/core/src/aura_hive/hive/proteins/persistence/receipts.py
+++ b/core/src/aura_hive/hive/proteins/persistence/receipts.py
@@ -31,9 +31,15 @@ class ReceiptRepository:
             session.add(
                 DecisionReceiptRecord(
                     dispute_token=dispute_token,
-                    decision_id=str(receipt.get("decisionId", "")),
-                    request_id=str(receipt.get("requestId", "")),
-                    issued_at=str(receipt.get("issuedAt", "")),
+                    # `or ""` rather than a `get` default: a key present with
+                    # a null value would otherwise store the literal string
+                    # "None", which is a row that exists and cannot be found.
+                    # betterproto omits empty fields rather than emitting null,
+                    # so a minted receipt cannot carry one — but this takes a
+                    # plain dict, and one from anywhere else can.
+                    decision_id=str(receipt.get("decisionId") or ""),
+                    request_id=str(receipt.get("requestId") or ""),
+                    issued_at=str(receipt.get("issuedAt") or ""),
                     receipt=receipt,
                 )
             )

--- a/core/src/aura_hive/hive/proteins/persistence/skill.py
+++ b/core/src/aura_hive/hive/proteins/persistence/skill.py
@@ -20,6 +20,7 @@ from .engine import (
     RedisCache,
 )
 from .items import ItemRepository
+from .receipts import ReceiptRepository
 from .wallet import WalletRepository
 
 logger = structlog.get_logger(__name__)
@@ -62,6 +63,8 @@ class PersistenceSkill(
             "sanctify_wallet": self._sanctify_wallet,
             "is_wallet_sanctified": self._is_wallet_sanctified,
             "log_metabolic_cost": self._log_metabolic_cost,
+            "record_receipt": self._record_receipt,
+            "find_receipt_by_dispute_token": self._find_receipt_by_dispute_token,
         }
 
         # Entity SQL lives in dedicated repositories; the _get_session reference
@@ -69,6 +72,7 @@ class PersistenceSkill(
         self._deals = DealRepository(self._get_session)
         self._items = ItemRepository(self._get_session)
         self._wallets = WalletRepository(self._get_session)
+        self._receipts = ReceiptRepository(self._get_session)
 
     def get_name(self) -> str:
         return "persistence"
@@ -276,6 +280,44 @@ class PersistenceSkill(
         if result:
             return Observation(success=True, metadata=make_struct(result))
         return Observation(success=False, error="deal_not_found")
+
+    async def _record_receipt(self, params: dict[str, Any]) -> Observation:
+        """
+        Store the auditor's copy. Failure is reported, never raised: the
+        Connector treats this as fail-open, because reporting on a decision
+        must not take that decision down.
+        """
+        receipt = params.get("receipt")
+        if not receipt:
+            return Observation(success=False, error="receipt_required")
+        dispute_token = params.get("dispute_token")
+        if not dispute_token:
+            return Observation(success=False, error="dispute_token_required")
+
+        try:
+            await asyncio.to_thread(self._receipts.record, receipt, dispute_token)
+            return Observation(success=True)
+        except Exception as e:
+            return Observation(success=False, error=str(e))
+
+    async def _find_receipt_by_dispute_token(
+        self, params: dict[str, Any]
+    ) -> Observation:
+        """
+        The query lives here rather than in the tool that calls it, so a
+        future internal endpoint is a second thin caller rather than a second
+        implementation.
+        """
+        token = params.get("dispute_token")
+        if not token:
+            return Observation(success=False, error="dispute_token_required")
+
+        result = await asyncio.to_thread(self._receipts.find_by_dispute_token, token)
+        if result is None:
+            # Not an error. A token that was never issued is a legitimate
+            # answer to give an auditor — someone may have invented it.
+            return Observation(success=False, error="not_found")
+        return Observation(success=True, metadata=make_struct({"receipt": result}))
 
     async def _update_deal_status(self, params: dict[str, Any]) -> Observation:
         deal_id = params.get("deal_id")

--- a/core/tests/test_receipt_capabilities.py
+++ b/core/tests/test_receipt_capabilities.py
@@ -1,0 +1,114 @@
+"""
+The lookup lives in the protein, not in the tool.
+
+A `make resolve-dispute` command and a future internal endpoint should be two
+thin callers of one query rather than two implementations of it.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from aura_hive.config.database import DatabaseSettings
+from aura_hive.hive.proteins.persistence.skill import PersistenceSkill
+
+
+def a_receipt() -> dict:
+    return {
+        "version": "AURA-RECEIPT-V2-UNSIGNED",
+        "claimHash": "a" * 64,
+        "decisionId": "dec-1111",
+        "requestId": "req-2222",
+        "issuedAt": "2026-08-12T10:00:00Z",
+    }
+
+
+def skill_with(session: MagicMock) -> PersistenceSkill:
+    skill = PersistenceSkill()
+    settings = DatabaseSettings(
+        url="postgresql://user:password@localhost:5432/aura_db",
+        redis_url="redis://localhost:6379/0",
+    )
+    skill.bind(settings, (MagicMock(return_value=session), MagicMock(), None))
+    return skill
+
+
+def a_session() -> MagicMock:
+    session = MagicMock()
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+    return session
+
+
+class TestRecording:
+    @pytest.mark.asyncio
+    async def test_a_receipt_is_recorded_under_its_token(self) -> None:
+        session = a_session()
+
+        obs = await skill_with(session).execute(
+            "record_receipt", {"receipt": a_receipt(), "dispute_token": "tok-abc"}
+        )
+
+        assert obs.success
+        assert session.add.call_args[0][0].dispute_token == "tok-abc"
+
+    @pytest.mark.asyncio
+    async def test_a_missing_token_is_refused_by_value(self) -> None:
+        obs = await skill_with(a_session()).execute(
+            "record_receipt", {"receipt": a_receipt()}
+        )
+
+        assert not obs.success
+        assert obs.error == "dispute_token_required"
+
+    @pytest.mark.asyncio
+    async def test_a_missing_receipt_is_refused_by_value(self) -> None:
+        obs = await skill_with(a_session()).execute(
+            "record_receipt", {"dispute_token": "tok-abc"}
+        )
+
+        assert not obs.success
+        assert obs.error == "receipt_required"
+
+    @pytest.mark.asyncio
+    async def test_a_database_failure_is_reported_not_raised(self) -> None:
+        """
+        The Connector treats this as fail-open, so it must come back as a
+        failed Observation rather than an exception crossing the boundary.
+        """
+        session = a_session()
+        session.commit.side_effect = RuntimeError("connection refused")
+
+        obs = await skill_with(session).execute(
+            "record_receipt", {"receipt": a_receipt(), "dispute_token": "tok-abc"}
+        )
+
+        assert not obs.success
+        assert "connection refused" in (obs.error or "")
+
+
+class TestFinding:
+    @pytest.mark.asyncio
+    async def test_a_known_token_returns_the_document(self) -> None:
+        session = a_session()
+        row = MagicMock()
+        row.receipt = a_receipt()
+        session.query.return_value.filter_by.return_value.first.return_value = row
+
+        obs = await skill_with(session).execute(
+            "find_receipt_by_dispute_token", {"dispute_token": "tok-abc"}
+        )
+
+        assert obs.success
+        assert obs.metadata.to_dict()["receipt"]["decisionId"] == "dec-1111"
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_token_is_not_found_rather_than_an_error(self) -> None:
+        session = a_session()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+
+        obs = await skill_with(session).execute(
+            "find_receipt_by_dispute_token", {"dispute_token": "never-issued"}
+        )
+
+        assert not obs.success
+        assert obs.error == "not_found"

--- a/core/tests/test_receipt_recording.py
+++ b/core/tests/test_receipt_recording.py
@@ -1,0 +1,123 @@
+"""
+Every decision is archived, including the ones that refused.
+
+`MetabolicLoop` calls `connector.act` unconditionally after the outbound
+Membrane, so a refusal reaches the Connector like anything else — and "you
+refused me" is the likeliest dispute a counterparty brings.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aura_core_gen.aura.core.v1 import (
+    ActionType,
+    Context,
+    DecisionReceipt,
+    HiveContextData,
+    Intent,
+    NegotiationIntent,
+    Observation,
+)
+from aura_hive.hive.connector.main import HiveConnector
+
+
+def a_decision(action: ActionType, token: str = "tok-abc") -> Intent:
+    intent = Intent(
+        action=action,
+        reasoning="LLM reasoning",
+        negotiation=NegotiationIntent(price=1200.0, message="offer"),
+    )
+    intent.dispute_token = token
+    intent.receipt = DecisionReceipt(
+        version="AURA-RECEIPT-V2-UNSIGNED",
+        decision_id="dec-1111",
+        request_id="req-2222",
+        issued_at="2026-08-12T10:00:00Z",
+    )
+    return intent
+
+
+def a_context() -> Context:
+    return Context(hive=HiveContextData(request_id="req-2222"))
+
+
+def connector_with(registry: MagicMock) -> HiveConnector:
+    return HiveConnector(registry=registry)
+
+
+def a_registry(record_result: Any = None) -> MagicMock:
+    registry = MagicMock()
+    registry.execute = AsyncMock(
+        return_value=record_result or Observation(success=True)
+    )
+    return registry
+
+
+class TestTheArchiveIsWritten:
+    @pytest.mark.asyncio
+    async def test_an_emitted_decision_is_recorded_under_its_token(self) -> None:
+        registry = a_registry()
+
+        await connector_with(registry).act(
+            a_decision(ActionType.ACTION_TYPE_COUNTER), a_context()
+        )
+
+        call = next(
+            c for c in registry.execute.await_args_list if c[0][1] == "record_receipt"
+        )
+        assert call[0][0] == "persistence"
+        assert call[0][2]["dispute_token"] == "tok-abc"
+        assert call[0][2]["receipt"]["decisionId"] == "dec-1111"
+
+    @pytest.mark.asyncio
+    async def test_a_refused_decision_is_recorded_too(self) -> None:
+        """The dispute most likely to arrive is about a refusal."""
+        registry = a_registry()
+
+        await connector_with(registry).act(
+            a_decision(ActionType.ACTION_TYPE_REJECT), a_context()
+        )
+
+        assert any(
+            c[0][1] == "record_receipt" for c in registry.execute.await_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_decision_with_no_receipt_records_nothing(self) -> None:
+        """An unwired Membrane mints none; there is nothing to archive."""
+        registry = a_registry()
+        intent = Intent(action=ActionType.ACTION_TYPE_COUNTER, reasoning="x")
+
+        await connector_with(registry).act(intent, a_context())
+
+        assert not any(
+            c[0][1] == "record_receipt" for c in registry.execute.await_args_list
+        )
+
+
+class TestTheArchiveNeverCostsTheDecision:
+    @pytest.mark.asyncio
+    async def test_a_failed_write_still_returns_an_observation(self) -> None:
+        registry = a_registry(Observation(success=False, error="connection refused"))
+
+        observation = await connector_with(registry).act(
+            a_decision(ActionType.ACTION_TYPE_COUNTER), a_context()
+        )
+
+        assert observation is not None
+
+    @pytest.mark.asyncio
+    async def test_a_raising_write_still_returns_an_observation(self) -> None:
+        """
+        The promise has to hold from where the code sits, not from someone
+        having checked that the protein never raises.
+        """
+        registry = MagicMock()
+        registry.execute = AsyncMock(side_effect=RuntimeError("pool exhausted"))
+
+        observation = await connector_with(registry).act(
+            a_decision(ActionType.ACTION_TYPE_COUNTER), a_context()
+        )
+
+        assert observation is not None

--- a/core/tests/test_receipt_recording.py
+++ b/core/tests/test_receipt_recording.py
@@ -109,6 +109,31 @@ class TestTheArchiveNeverCostsTheDecision:
         assert observation is not None
 
     @pytest.mark.asyncio
+    async def test_the_archive_step_survives_something_that_is_not_an_intent(
+        self,
+    ) -> None:
+        """
+        `act` is declared `(action: Any, ...)`, and the guard used to read
+        `action.receipt` outside the try — so anything that was not an Intent
+        raised an AttributeError straight past every piece of fail-open
+        handling.
+
+        Asserted against `_record_receipt` rather than `act`, and the
+        distinction is the point: the Genome's `act` hands a `None` to
+        `_handle_legacy`, which reads `action.action` and raises. That is
+        pre-existing and not this change's to fix or to claim. What is claimed
+        here is narrower and true — the archive step added by this branch does
+        not turn a malformed action into a lost decision.
+        """
+        registry = a_registry()
+
+        await connector_with(registry)._record_receipt(None)
+
+        assert not any(
+            c[0][1] == "record_receipt" for c in registry.execute.await_args_list
+        )
+
+    @pytest.mark.asyncio
     async def test_a_hanging_write_is_abandoned_rather_than_waited_on(self) -> None:
         """
         The failure mode a refused connection does not cover.

--- a/core/tests/test_receipt_recording.py
+++ b/core/tests/test_receipt_recording.py
@@ -6,8 +6,9 @@ Membrane, so a refusal reaches the Connector like anything else — and "you
 refused me" is the likeliest dispute a counterparty brings.
 """
 
+import asyncio
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aura_core_gen.aura.core.v1 import (
@@ -104,6 +105,35 @@ class TestTheArchiveNeverCostsTheDecision:
         observation = await connector_with(registry).act(
             a_decision(ActionType.ACTION_TYPE_COUNTER), a_context()
         )
+
+        assert observation is not None
+
+    @pytest.mark.asyncio
+    async def test_a_hanging_write_is_abandoned_rather_than_waited_on(self) -> None:
+        """
+        The failure mode a refused connection does not cover.
+
+        A refused connect raises in milliseconds. A blackholed one does not
+        raise at all — psycopg2 sits in the kernel's TCP retry for minutes,
+        serially, ahead of the decision, on every call including the refusals
+        that did no database work before this change. Fail-open against
+        exceptions is only half the promise.
+        """
+        import aura_hive.hive.connector.main as connector_main
+
+        async def never_returns(*args: Any, **kwargs: Any) -> Any:
+            await asyncio.sleep(60)
+
+        registry = MagicMock()
+        registry.execute = never_returns
+
+        with patch.object(connector_main, "_ARCHIVE_TIMEOUT_SECONDS", 0.05):
+            observation = await asyncio.wait_for(
+                connector_with(registry).act(
+                    a_decision(ActionType.ACTION_TYPE_COUNTER), a_context()
+                ),
+                timeout=5,
+            )
 
         assert observation is not None
 

--- a/core/tests/test_receipt_repository.py
+++ b/core/tests/test_receipt_repository.py
@@ -88,6 +88,31 @@ class TestRecording:
         assert parsed.canonical_prefix == "c" * 16
 
 
+class TestADocumentThatCarriesNulls:
+    def test_a_null_field_stores_an_empty_string_not_the_word_none(self) -> None:
+        """
+        `str(None)` is `"None"`, and an indexed column holding that literal is
+        a row that exists and cannot be found — the worst shape of silent
+        corruption for an archive whose only job is to be searchable.
+
+        betterproto omits empty fields rather than emitting null, so a receipt
+        minted here cannot carry one. A dict reaching this repository from
+        anywhere else — a JSON blob with explicit nulls, a future caller — can.
+        """
+        session = a_session()
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        repo.record(
+            a_receipt() | {"decisionId": None, "requestId": None, "issuedAt": None},
+            dispute_token="tok-abc",
+        )
+
+        row = session.add.call_args[0][0]
+        assert row.decision_id == ""
+        assert row.request_id == ""
+        assert row.issued_at == ""
+
+
 class TestFinding:
     def test_a_known_token_returns_the_document(self) -> None:
         session = a_session()

--- a/core/tests/test_receipt_repository.py
+++ b/core/tests/test_receipt_repository.py
@@ -1,0 +1,130 @@
+"""
+Receipts survive the log they used to live in.
+
+`DECISION_RECEIPT.md` §7 says the log line makes the log the store. It does,
+for days to weeks: the stream goes to a Loki outside this repository with a
+short retention, and nothing wrote a receipt anywhere else. A dispute arriving
+a month after the decision found nothing.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+from aura_core_gen.aura.core.v1 import DecisionReceipt
+from aura_hive.hive.proteins.persistence.receipts import ReceiptRepository
+
+
+def a_receipt() -> dict:
+    """A receipt dict in the shape `to_dict()` produces — camelCase keys."""
+    return {
+        "version": "AURA-RECEIPT-V2-UNSIGNED",
+        "claimHash": "a" * 64,
+        "emissionHash": "b" * 64,
+        "outcome": "DECISION_OUTCOME_EMIT",
+        "outcomeGate": "",
+        "canonicalPrefix": "c" * 16,
+        "issuedAt": "2026-08-12T10:00:00Z",
+        "decisionId": "dec-1111",
+        "requestId": "req-2222",
+        "rulesetVersion": "guard/negotiation@2.0.0+deadbeef",
+    }
+
+
+def a_session() -> MagicMock:
+    session = MagicMock()
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+    return session
+
+
+class TestRecording:
+    def test_the_indexed_columns_are_taken_from_the_document(self) -> None:
+        """
+        Derived here rather than passed in, so an index cannot disagree with
+        the receipt it indexes.
+        """
+        session = a_session()
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        repo.record(a_receipt(), dispute_token="tok-abc")
+
+        row = session.add.call_args[0][0]
+        assert row.dispute_token == "tok-abc"
+        assert row.decision_id == "dec-1111"
+        assert row.request_id == "req-2222"
+        assert row.issued_at == "2026-08-12T10:00:00Z"
+        assert row.receipt == a_receipt()
+        session.commit.assert_called_once()
+
+    def test_the_whole_document_is_stored_not_a_decomposition(self) -> None:
+        """
+        `verify()` takes a document. Every normalisation is a chance to
+        reassemble something at read time that differs from what was signed.
+        """
+        session = a_session()
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        repo.record(a_receipt(), dispute_token="tok-abc")
+
+        stored = session.add.call_args[0][0].receipt
+        assert stored == a_receipt()
+
+    def test_a_stored_receipt_survives_json_and_still_parses(self) -> None:
+        """
+        The column is JSON, so the document goes through a serialisation the
+        receipt never asked for. This is the property the whole archive rests
+        on: what comes back must be the document that was signed.
+        """
+        session = a_session()
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        repo.record(a_receipt(), dispute_token="tok-abc")
+        stored = session.add.call_args[0][0].receipt
+
+        parsed = DecisionReceipt().from_dict(json.loads(json.dumps(stored)))
+
+        assert parsed.decision_id == "dec-1111"
+        assert parsed.claim_hash == "a" * 64
+        assert parsed.canonical_prefix == "c" * 16
+
+
+class TestFinding:
+    def test_a_known_token_returns_the_document(self) -> None:
+        session = a_session()
+        row = MagicMock()
+        row.receipt = a_receipt()
+        session.query.return_value.filter_by.return_value.first.return_value = row
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        assert repo.find_by_dispute_token("tok-abc") == a_receipt()
+
+    def test_an_unknown_token_returns_nothing_rather_than_raising(self) -> None:
+        """
+        A token that was never issued is a legitimate answer to give an
+        auditor — someone may have invented it — not a failure.
+        """
+        session = a_session()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        assert repo.find_by_dispute_token("never-issued") is None
+
+
+class TestASessionCanBeReassembled:
+    def test_two_decisions_in_one_session_share_a_request_id(self) -> None:
+        """
+        `request_id` exists so an auditor holding one token can pull the whole
+        negotiation rather than the single turn they were cited. Nothing else
+        asserts the field, so it would rot unnoticed.
+        """
+        session = a_session()
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        first = a_receipt()
+        second = a_receipt() | {"decisionId": "dec-3333"}
+        repo.record(first, dispute_token="tok-one")
+        repo.record(second, dispute_token="tok-two")
+
+        rows = [call[0][0] for call in session.add.call_args_list]
+        assert [row.decision_id for row in rows] == ["dec-1111", "dec-3333"]
+        assert {row.request_id for row in rows} == {"req-2222"}

--- a/core/tests/test_resolve_dispute_tool.py
+++ b/core/tests/test_resolve_dispute_tool.py
@@ -1,0 +1,111 @@
+"""
+What an auditor gets when a counterparty cites a token.
+
+Not just the document: the document plus whether it holds up. In a dispute the
+second question is the one being asked.
+
+The receipt here is minted by a real Membrane rather than written by hand. A
+hand-built one cannot pass `verify()` — `canonical_prefix` is a digest of the
+content fields, so inventing it makes the document fail for a reason that has
+nothing to do with what is under test, and the exit code would be asserting
+the fixture's invalidity rather than the tool's behaviour.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from aura_core import SkillRegistry
+from aura_core.struct_utils import make_struct
+from aura_core_gen.aura.core.v1 import (
+    ActionType,
+    Context,
+    HiveContextData,
+    Intent,
+    NegotiationIntent,
+)
+from aura_hive.hive.membrane.main import HiveMembrane
+from aura_hive.hive.proteins.guard import GuardSkill
+from aura_hive.hive.proteins.guard.engine import OutputGuard
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+from resolve_dispute import render  # noqa: E402
+
+
+class _Safety:
+    min_profit_margin = 0.10
+    ui_trigger_price = 100000.0
+    trade_risk_threshold = 0.10
+
+
+async def a_minted_receipt() -> dict:
+    """A receipt as the archive stores it: whatever `to_dict()` produced."""
+    registry = SkillRegistry()
+    guard = GuardSkill()
+    guard.bind(_Safety(), OutputGuard(safety_settings=_Safety()))
+    registry.register(guard.get_name(), guard)
+
+    decision = await HiveMembrane(registry=registry).inspect_outbound(
+        Intent(
+            action=ActionType.ACTION_TYPE_COUNTER,
+            reasoning="LLM reasoning",
+            negotiation=NegotiationIntent(price=2000.0, message="Here is my offer"),
+        ),
+        Context(
+            metadata=make_struct({"floor_price": "1000.0", "internal_cost": "777.0"}),
+            hive=HiveContextData(request_id="req-2222"),
+        ),
+    )
+    return dict(decision.receipt.to_dict())
+
+
+@pytest.mark.asyncio
+async def test_a_found_receipt_is_reported_with_its_verdict() -> None:
+    receipt = await a_minted_receipt()
+
+    report, code = render(receipt)
+
+    assert receipt["decisionId"] in report
+    assert "req-2222" in report
+    assert "verify         ok" in report
+    assert code == 0
+
+
+@pytest.mark.asyncio
+async def test_an_unsigned_receipt_is_named_as_unattested() -> None:
+    """
+    The auditor must not read "verified" as "vouched for". §7 keeps the two
+    version names apart precisely so this distinction survives, and this
+    Membrane has no attestation protein wired.
+    """
+    report, _ = render(await a_minted_receipt())
+
+    assert "not attested" in report.lower()
+
+
+@pytest.mark.asyncio
+async def test_a_tampered_receipt_is_reported_as_failing() -> None:
+    """
+    The verdict is the point of the tool. A document that no longer matches
+    its own digests must be named as failing, and the exit code must carry it
+    so the command can gate something.
+    """
+    receipt = await a_minted_receipt()
+    receipt["canonicalPrefix"] = "0" * 16
+
+    report, code = render(receipt)
+
+    assert "FAILED" in report
+    assert code == 1
+
+
+def test_a_missing_receipt_is_an_answer_not_a_failure() -> None:
+    """
+    A token that was never issued is a legitimate thing to tell an auditor.
+    Exit 0, because the tool answered.
+    """
+    report, code = render(None)
+
+    assert "not found" in report.lower()
+    assert code == 0

--- a/docs/DECISION_RECEIPT.md
+++ b/docs/DECISION_RECEIPT.md
@@ -980,7 +980,19 @@ everything before it.
 
 **This is the consumer that was missing when step 6 was written off as unbuildable** (§6). The
 verifier had existed since the receipt did and ran only in tests, because no receipt was persisted
-anywhere. The log line makes the log the store, and the tool makes it read.
+anywhere. The log line makes the log *a* store, and the tool makes it read.
+
+**The log is not the durable store, and treating it as one was the gap.** It goes to a Loki outside
+this repository whose retention is measured in days to weeks, so a dispute arriving a month after the
+decision found nothing — the receipt had expired, signature and all. Every decision is now also
+written to `decision_receipts` by the Connector on the C step, keyed by `dispute_token`, and
+`make resolve-dispute TOKEN=…` turns a counterparty's citation into the receipt plus its verdict.
+
+The write is fail-open, like the log line and for the same reason: reporting on a decision must never
+take that decision down. The cost is that archive holes are possible and silent, so a failure emits
+`receipt_record_failed` as its own event — an archive that sometimes never arrives is worse than one
+that expires, because nothing announces it. The log line stays as an independent second path, and
+survives Postgres being unreachable.
 
 The gateway's two receipt renderers are gone with the response field. `receipt_to_json_full` never
 had a production caller — the log line lives in core and carries betterproto's own `to_dict()` — and
@@ -1192,11 +1204,16 @@ format above is the contract, and a consumer reimplementing it owes us nothing.
    nothing to run against on both counts.
 
    **What was actually missing was a consumer, and it now exists.** The `membrane_receipt` log line
-   carries the whole document, which makes the log the store; `tools/verify_receipts.py` and
-   `make verify-receipts` run `verify()` over that stream and report totals, failures and the
-   `unverifiable` tally, exiting non-zero when anything failed. No schema, no migration, no new
-   responsibility on `PersistenceSkill`. Storing receipts properly is still open — see step 4 — but
-   the receipt is no longer a document nobody reads.
+   carries the whole document; `tools/verify_receipts.py` and `make verify-receipts` run `verify()`
+   over that stream and report totals, failures and the `unverifiable` tally, exiting non-zero when
+   anything failed.
+
+   That first pass claimed the log line "makes the log the store", and added that storing receipts
+   properly was still open. Both were written in the same breath and the first quietly undid the
+   second: a store with a retention of days is a buffer. Receipts are now written to
+   `decision_receipts` by the Connector, resolvable by `dispute_token` through
+   `make resolve-dispute` (§7), and the log line remains as an independent second path rather than
+   as the archive.
 7. ~~Declare ψ and check it on the emitted value.~~ **DONE**, and not in the original plan — it was
    added because writing down what the rule set guarantees found the bug in §3.8. `postcondition` in
    `ruleset.yaml` at `2.0.0`, clause predicates in `engine.py` cross-checked against the declaration

--- a/docs/DECISION_RECEIPT.md
+++ b/docs/DECISION_RECEIPT.md
@@ -984,9 +984,12 @@ anywhere. The log line makes the log *a* store, and the tool makes it read.
 
 **The log is not the durable store, and treating it as one was the gap.** It goes to a Loki outside
 this repository whose retention is measured in days to weeks, so a dispute arriving a month after the
-decision found nothing — the receipt had expired, signature and all. Every decision is now also
-written to `decision_receipts` by the Connector on the C step, keyed by `dispute_token`, and
-`make resolve-dispute TOKEN=…` turns a counterparty's citation into the receipt plus its verdict.
+decision found nothing — the receipt had expired, signature and all. Every decision the Membrane
+minted a receipt for is now also written to `decision_receipts` by the Connector on the C step, keyed
+by `dispute_token`, and `make resolve-dispute TOKEN=…` turns a counterparty's citation into the
+receipt plus its verdict. Refusals included — every refusal path returns through `_finish`, which
+mints and stamps the token unconditionally. A Membrane that was never wired mints nothing, and there
+is correspondingly nothing to archive.
 
 The write is fail-open, like the log line and for the same reason: reporting on a decision must never
 take that decision down. The cost is that archive holes are possible and silent, so a failure emits

--- a/docs/superpowers/plans/2026-08-12-receipt-durability.md
+++ b/docs/superpowers/plans/2026-08-12-receipt-durability.md
@@ -1,0 +1,1013 @@
+# Receipt Durability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make decision receipts outlive the short-retention log they currently live in, and give the auditor one command that turns a `dispute_token` into a verified receipt.
+
+**Architecture:** The Connector writes every receipt to Postgres on the C step, fail-open, through two new capabilities on the persistence protein. The lookup lives in the protein rather than in the tool, so a future internal endpoint is a second thin caller. The `membrane_receipt` log line stays as an independent second path.
+
+**Tech Stack:** Python 3.12, SQLAlchemy 2 (`DeclarativeBase` / `Mapped`), betterproto, pytest, structlog, uv.
+
+**Spec:** `docs/superpowers/specs/2026-08-12-receipt-durability-design.md`
+
+## Global Constraints
+
+- Package manager is `uv`. Never `pip` or `poetry`.
+- Run core tests as: `PYTHONPATH=core/src:core/gen-proto:packages/aura-core/src:packages/aura-core/gen-proto uv run pytest <path> -v`
+- Proteins follow the Trinity pattern: `bind(settings, provider)` → `async initialize() -> bool` → `async execute(intent, params) -> Observation`.
+- Entity SQL lives in a repository class, never inline in the skill. Handlers stay thin: `params -> repo -> Observation`. Repository methods are **synchronous**; handlers wrap them in `asyncio.to_thread`.
+- Never edit generated protobuf code (`*/gen-proto/`, `aura_core_gen`).
+- Biological naming. `Manager`/`Service`/`Helper`/`Handler` are forbidden as type names.
+- `make lint` must exit 0 before every commit.
+- ruff treats `aura_hive` as third-party: imports sort into one block with `pytest`, `sqlalchemy`, `eth_account` etc., alphabetically. `aura_core` < `aura_core_gen` < `aura_hive` < `pytest` < `sqlalchemy`.
+- **Recording a receipt must never fail a decision.** Every write path is fail-open.
+- A receipt carries no price and no premise value — only digests, identifiers, enums, timestamps and signature metadata. Nothing in this plan may add one.
+- **Verified fact this plan relies on:** `DecisionReceipt().from_dict(json.loads(json.dumps(receipt.to_dict())))` verifies and stays attested. Storing the whole document as JSON is lossless.
+
+---
+
+### Task 1: The row and the repository
+
+**Files:**
+- Modify: `core/src/aura_hive/hive/proteins/persistence/engine.py` (add a model after `MetabolicCost`)
+- Create: `core/src/aura_hive/hive/proteins/persistence/receipts.py`
+- Test: `core/tests/test_receipt_repository.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `DecisionReceiptRecord` — SQLAlchemy model, `__tablename__ = "decision_receipts"`.
+  - `ReceiptRepository(session_factory)` with synchronous `record(receipt: dict, dispute_token: str) -> None` and `find_by_dispute_token(token: str) -> dict | None`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/tests/test_receipt_repository.py`:
+
+```python
+"""
+Receipts survive the log they used to live in.
+
+`DECISION_RECEIPT.md` §7 says the log line makes the log the store. It does,
+for days to weeks: the stream goes to a Loki outside this repository with a
+short retention, and nothing wrote a receipt anywhere else. A dispute arriving
+a month after the decision found nothing.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+from aura_core_gen.aura.core.v1 import DecisionReceipt
+from aura_hive.hive.proteins.persistence.receipts import ReceiptRepository
+
+
+def a_receipt() -> dict:
+    """A receipt dict in the shape `to_dict()` produces — camelCase keys."""
+    return {
+        "version": "AURA-RECEIPT-V2-UNSIGNED",
+        "claimHash": "a" * 64,
+        "emissionHash": "b" * 64,
+        "outcome": "DECISION_OUTCOME_EMIT",
+        "outcomeGate": "",
+        "canonicalPrefix": "c" * 16,
+        "issuedAt": "2026-08-12T10:00:00Z",
+        "decisionId": "dec-1111",
+        "requestId": "req-2222",
+        "rulesetVersion": "guard/negotiation@2.0.0+deadbeef",
+    }
+
+
+def a_session() -> MagicMock:
+    session = MagicMock()
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+    return session
+
+
+class TestRecording:
+    def test_the_indexed_columns_are_taken_from_the_document(self) -> None:
+        """
+        Derived here rather than passed in, so an index cannot disagree with
+        the receipt it indexes.
+        """
+        session = a_session()
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        repo.record(a_receipt(), dispute_token="tok-abc")
+
+        row = session.add.call_args[0][0]
+        assert row.dispute_token == "tok-abc"
+        assert row.decision_id == "dec-1111"
+        assert row.request_id == "req-2222"
+        assert row.issued_at == "2026-08-12T10:00:00Z"
+        assert row.receipt == a_receipt()
+        session.commit.assert_called_once()
+
+    def test_the_whole_document_is_stored_not_a_decomposition(self) -> None:
+        """
+        `verify()` takes a document. Every normalisation is a chance to
+        reassemble something at read time that differs from what was signed.
+        """
+        session = a_session()
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        repo.record(a_receipt(), dispute_token="tok-abc")
+
+        stored = session.add.call_args[0][0].receipt
+        assert stored == a_receipt()
+
+    def test_a_stored_receipt_survives_json_and_still_parses(self) -> None:
+        """
+        The column is JSON, so the document goes through a serialisation the
+        receipt never asked for. This is the property the whole archive rests
+        on: what comes back must be the document that was signed.
+        """
+        session = a_session()
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        repo.record(a_receipt(), dispute_token="tok-abc")
+        stored = session.add.call_args[0][0].receipt
+
+        parsed = DecisionReceipt().from_dict(json.loads(json.dumps(stored)))
+
+        assert parsed.decision_id == "dec-1111"
+        assert parsed.claim_hash == "a" * 64
+        assert parsed.canonical_prefix == "c" * 16
+
+
+class TestFinding:
+    def test_a_known_token_returns_the_document(self) -> None:
+        session = a_session()
+        row = MagicMock()
+        row.receipt = a_receipt()
+        session.query.return_value.filter_by.return_value.first.return_value = row
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        assert repo.find_by_dispute_token("tok-abc") == a_receipt()
+
+    def test_an_unknown_token_returns_nothing_rather_than_raising(self) -> None:
+        """
+        A token that was never issued is a legitimate answer to give an
+        auditor — someone may have invented it — not a failure.
+        """
+        session = a_session()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        assert repo.find_by_dispute_token("never-issued") is None
+
+
+class TestASessionCanBeReassembled:
+    def test_two_decisions_in_one_session_share_a_request_id(self) -> None:
+        """
+        `request_id` exists so an auditor holding one token can pull the whole
+        negotiation rather than the single turn they were cited. Nothing else
+        asserts the field, so it would rot unnoticed.
+        """
+        session = a_session()
+        repo = ReceiptRepository(MagicMock(return_value=session))
+
+        first = a_receipt()
+        second = a_receipt() | {"decisionId": "dec-3333"}
+        repo.record(first, dispute_token="tok-one")
+        repo.record(second, dispute_token="tok-two")
+
+        rows = [call[0][0] for call in session.add.call_args_list]
+        assert [row.decision_id for row in rows] == ["dec-1111", "dec-3333"]
+        assert {row.request_id for row in rows} == {"req-2222"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=core/src:core/gen-proto:packages/aura-core/src:packages/aura-core/gen-proto uv run pytest core/tests/test_receipt_repository.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aura_hive.hive.proteins.persistence.receipts'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `core/src/aura_hive/hive/proteins/persistence/engine.py`, add after the `MetabolicCost` model:
+
+```python
+class DecisionReceiptRecord(Base):
+    """
+    The auditor's copy of a decision receipt.
+
+    The log line was the only store, and it lives in a Loki with a short
+    retention — so a dispute arriving a month after the decision found nothing.
+    This table is what makes the corpus outlive the stream; the log line stays
+    as a second, independent path.
+
+    Nothing here is a price or a premise. Every receipt field is a digest, an
+    identifier, an enum, a timestamp or signature metadata, which is why the
+    whole document can be stored without becoming a new place the floor lives.
+    """
+
+    __tablename__ = "decision_receipts"
+
+    id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    # What the counterparty cites. The lookup key.
+    dispute_token: Mapped[str] = mapped_column(
+        String, nullable=False, unique=True, index=True
+    )
+    # What the signature binds — the auditor's other way in.
+    decision_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    # The session, for reassembling a whole negotiation.
+    request_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    # The receipt's own timestamp, kept as the string it carries rather than
+    # parsed into a DateTime, so the column holds what was signed instead of a
+    # reconstruction of it.
+    issued_at: Mapped[str] = mapped_column(String, nullable=False)
+    # The whole document, exactly as the log line carries it.
+    receipt: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    # When the row was written — deliberately separate from `issued_at`, so a
+    # divergence between deciding and recording is visible rather than hidden.
+    recorded_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(UTC)
+    )
+```
+
+**No import changes are needed.** `engine.py` already imports every name this model uses — `uuid`,
+`UTC`, `datetime`, `Any`, `String`, `DateTime`, `JSONB`, `Mapped`, `mapped_column`. Verified against
+the file; if ruff disagrees, something else moved and is worth reading before adding anything.
+
+Create `core/src/aura_hive/hive/proteins/persistence/receipts.py`:
+
+```python
+"""ReceiptRepository — the auditor's copy of every decision receipt.
+
+Keeps the receipt SQL in one place so the skill's handlers stay thin
+(params -> repo -> Observation). Methods are synchronous; callers wrap them in
+``asyncio.to_thread`` exactly as the other repositories are called.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from .engine import DecisionReceiptRecord
+
+
+class ReceiptRepository:
+    """Write-once storage for decision receipts, read by dispute token."""
+
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        self._session = session_factory
+
+    def record(self, receipt: dict[str, Any], dispute_token: str) -> None:
+        """
+        Store a receipt under the token the counterparty was given.
+
+        The indexed columns are derived from the document rather than passed
+        in beside it, so an index cannot come to disagree with the receipt it
+        indexes.
+        """
+        with self._session() as session:
+            session.add(
+                DecisionReceiptRecord(
+                    dispute_token=dispute_token,
+                    decision_id=str(receipt.get("decisionId", "")),
+                    request_id=str(receipt.get("requestId", "")),
+                    issued_at=str(receipt.get("issuedAt", "")),
+                    receipt=receipt,
+                )
+            )
+            session.commit()
+
+    def find_by_dispute_token(self, token: str) -> dict[str, Any] | None:
+        """The document, or None. An unissued token is an answer, not a fault."""
+        with self._session() as session:
+            row = (
+                session.query(DecisionReceiptRecord)
+                .filter_by(dispute_token=token)
+                .first()
+            )
+            return dict(row.receipt) if row else None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=core/src:core/gen-proto:packages/aura-core/src:packages/aura-core/gen-proto uv run pytest core/tests/test_receipt_repository.py -v`
+Expected: PASS (6 passed)
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+make lint
+git add core/src/aura_hive/hive/proteins/persistence/engine.py core/src/aura_hive/hive/proteins/persistence/receipts.py core/tests/test_receipt_repository.py
+git commit -m "feat(persistence): a table that outlives the log receipts were stored in"
+```
+
+---
+
+### Task 2: The two capabilities
+
+**Files:**
+- Modify: `core/src/aura_hive/hive/proteins/persistence/skill.py` (`_capabilities` map ~line 48-65; repository wiring ~line 69-71; new handlers beside `_get_deal_by_memo_handler`)
+- Test: `core/tests/test_receipt_capabilities.py`
+
+**Interfaces:**
+- Consumes: `ReceiptRepository` from Task 1.
+- Produces:
+  - `record_receipt` — params `{"receipt": dict, "dispute_token": str}` → `Observation(success=True)`, or `Observation(success=False, error=...)`.
+  - `find_receipt_by_dispute_token` — params `{"dispute_token": str}` → `Observation(success=True, metadata={"receipt": dict})` or `Observation(success=False, error="not_found")`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/tests/test_receipt_capabilities.py`:
+
+```python
+"""
+The lookup lives in the protein, not in the tool.
+
+A `make resolve-dispute` command and a future internal endpoint should be two
+thin callers of one query rather than two implementations of it.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from aura_hive.config.database import DatabaseSettings
+from aura_hive.hive.proteins.persistence.skill import PersistenceSkill
+
+
+def a_receipt() -> dict:
+    return {
+        "version": "AURA-RECEIPT-V2-UNSIGNED",
+        "claimHash": "a" * 64,
+        "decisionId": "dec-1111",
+        "requestId": "req-2222",
+        "issuedAt": "2026-08-12T10:00:00Z",
+    }
+
+
+def skill_with(session: MagicMock) -> PersistenceSkill:
+    skill = PersistenceSkill()
+    settings = DatabaseSettings(
+        url="postgresql://user:password@localhost:5432/aura_db",
+        redis_url="redis://localhost:6379/0",
+    )
+    skill.bind(settings, (MagicMock(return_value=session), MagicMock(), None))
+    return skill
+
+
+def a_session() -> MagicMock:
+    session = MagicMock()
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+    return session
+
+
+class TestRecording:
+    @pytest.mark.asyncio
+    async def test_a_receipt_is_recorded_under_its_token(self) -> None:
+        session = a_session()
+
+        obs = await skill_with(session).execute(
+            "record_receipt", {"receipt": a_receipt(), "dispute_token": "tok-abc"}
+        )
+
+        assert obs.success
+        assert session.add.call_args[0][0].dispute_token == "tok-abc"
+
+    @pytest.mark.asyncio
+    async def test_a_missing_token_is_refused_by_value(self) -> None:
+        obs = await skill_with(a_session()).execute(
+            "record_receipt", {"receipt": a_receipt()}
+        )
+
+        assert not obs.success
+        assert obs.error == "dispute_token_required"
+
+    @pytest.mark.asyncio
+    async def test_a_missing_receipt_is_refused_by_value(self) -> None:
+        obs = await skill_with(a_session()).execute(
+            "record_receipt", {"dispute_token": "tok-abc"}
+        )
+
+        assert not obs.success
+        assert obs.error == "receipt_required"
+
+    @pytest.mark.asyncio
+    async def test_a_database_failure_is_reported_not_raised(self) -> None:
+        """
+        The Connector treats this as fail-open, so it must come back as a
+        failed Observation rather than an exception crossing the boundary.
+        """
+        session = a_session()
+        session.commit.side_effect = RuntimeError("connection refused")
+
+        obs = await skill_with(session).execute(
+            "record_receipt", {"receipt": a_receipt(), "dispute_token": "tok-abc"}
+        )
+
+        assert not obs.success
+        assert "connection refused" in (obs.error or "")
+
+
+class TestFinding:
+    @pytest.mark.asyncio
+    async def test_a_known_token_returns_the_document(self) -> None:
+        session = a_session()
+        row = MagicMock()
+        row.receipt = a_receipt()
+        session.query.return_value.filter_by.return_value.first.return_value = row
+
+        obs = await skill_with(session).execute(
+            "find_receipt_by_dispute_token", {"dispute_token": "tok-abc"}
+        )
+
+        assert obs.success
+        assert obs.metadata.to_dict()["receipt"]["decisionId"] == "dec-1111"
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_token_is_not_found_rather_than_an_error(self) -> None:
+        session = a_session()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+
+        obs = await skill_with(session).execute(
+            "find_receipt_by_dispute_token", {"dispute_token": "never-issued"}
+        )
+
+        assert not obs.success
+        assert obs.error == "not_found"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=core/src:core/gen-proto:packages/aura-core/src:packages/aura-core/gen-proto uv run pytest core/tests/test_receipt_capabilities.py -v`
+Expected: FAIL — `Unknown intent: record_receipt`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `skill.py`, import the repository beside the others:
+
+```python
+from .receipts import ReceiptRepository
+```
+
+Add to the `_capabilities` map, after `"log_metabolic_cost"`:
+
+```python
+            "record_receipt": self._record_receipt,
+            "find_receipt_by_dispute_token": self._find_receipt_by_dispute_token,
+```
+
+Wire the repository beside `self._wallets`:
+
+```python
+        self._receipts = ReceiptRepository(self._get_session)
+```
+
+Add the two handlers beside `_get_deal_by_memo_handler`:
+
+```python
+    async def _record_receipt(self, params: dict[str, Any]) -> Observation:
+        """
+        Store the auditor's copy. Failure is reported, never raised: the
+        Connector treats this as fail-open, because reporting on a decision
+        must not take that decision down.
+        """
+        receipt = params.get("receipt")
+        if not receipt:
+            return Observation(success=False, error="receipt_required")
+        dispute_token = params.get("dispute_token")
+        if not dispute_token:
+            return Observation(success=False, error="dispute_token_required")
+
+        try:
+            await asyncio.to_thread(self._receipts.record, receipt, dispute_token)
+            return Observation(success=True)
+        except Exception as e:
+            return Observation(success=False, error=str(e))
+
+    async def _find_receipt_by_dispute_token(
+        self, params: dict[str, Any]
+    ) -> Observation:
+        """
+        The query lives here rather than in the tool that calls it, so a
+        future internal endpoint is a second thin caller rather than a second
+        implementation.
+        """
+        token = params.get("dispute_token")
+        if not token:
+            return Observation(success=False, error="dispute_token_required")
+
+        result = await asyncio.to_thread(
+            self._receipts.find_by_dispute_token, token
+        )
+        if result is None:
+            # Not an error. A token that was never issued is a legitimate
+            # answer to give an auditor — someone may have invented it.
+            return Observation(success=False, error="not_found")
+        return Observation(success=True, metadata=make_struct({"receipt": result}))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=core/src:core/gen-proto:packages/aura-core/src:packages/aura-core/gen-proto uv run pytest core/tests/test_receipt_capabilities.py -v`
+Expected: PASS (6 passed)
+
+- [ ] **Step 5: Run the persistence suite**
+
+Run: `PYTHONPATH=core/src:core/gen-proto:packages/aura-core/src:packages/aura-core/gen-proto uv run pytest core/tests/test_persistence_skill.py core/tests/test_persistence_wallet.py -v`
+Expected: PASS — the capability map grew, nothing else changed.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+make lint
+git add core/src/aura_hive/hive/proteins/persistence/skill.py core/tests/test_receipt_capabilities.py
+git commit -m "feat(persistence): record and resolve a receipt by its dispute token"
+```
+
+---
+
+### Task 3: The Connector records every decision
+
+**Files:**
+- Modify: `core/src/aura_hive/hive/connector/main.py` (add an `act` override on `HiveConnector`, after `__init__` at line ~42-46)
+- Test: `core/tests/test_receipt_recording.py`
+
+**Interfaces:**
+- Consumes: `record_receipt` from Task 2.
+- Produces: `HiveConnector.act(action, context)` — records the receipt, then delegates to `BaseConnector.act`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/tests/test_receipt_recording.py`:
+
+```python
+"""
+Every decision is archived, including the ones that refused.
+
+`MetabolicLoop` calls `connector.act` unconditionally after the outbound
+Membrane, so a refusal reaches the Connector like anything else — and "you
+refused me" is the likeliest dispute a counterparty brings.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aura_core_gen.aura.core.v1 import (
+    ActionType,
+    Context,
+    DecisionReceipt,
+    HiveContextData,
+    Intent,
+    NegotiationIntent,
+    Observation,
+)
+from aura_hive.hive.connector.main import HiveConnector
+
+
+def a_decision(action: ActionType, token: str = "tok-abc") -> Intent:
+    intent = Intent(
+        action=action,
+        reasoning="LLM reasoning",
+        negotiation=NegotiationIntent(price=1200.0, message="offer"),
+    )
+    intent.dispute_token = token
+    intent.receipt = DecisionReceipt(
+        version="AURA-RECEIPT-V2-UNSIGNED",
+        decision_id="dec-1111",
+        request_id="req-2222",
+        issued_at="2026-08-12T10:00:00Z",
+    )
+    return intent
+
+
+def a_context() -> Context:
+    return Context(hive=HiveContextData(request_id="req-2222"))
+
+
+def connector_with(registry: MagicMock) -> HiveConnector:
+    return HiveConnector(registry=registry)
+
+
+def a_registry(record_result: Any = None) -> MagicMock:
+    registry = MagicMock()
+    registry.execute = AsyncMock(
+        return_value=record_result or Observation(success=True)
+    )
+    return registry
+
+
+class TestTheArchiveIsWritten:
+    @pytest.mark.asyncio
+    async def test_an_emitted_decision_is_recorded_under_its_token(self) -> None:
+        registry = a_registry()
+
+        await connector_with(registry).act(
+            a_decision(ActionType.ACTION_TYPE_COUNTER), a_context()
+        )
+
+        call = next(
+            c for c in registry.execute.await_args_list if c[0][1] == "record_receipt"
+        )
+        assert call[0][0] == "persistence"
+        assert call[0][2]["dispute_token"] == "tok-abc"
+        assert call[0][2]["receipt"]["decisionId"] == "dec-1111"
+
+    @pytest.mark.asyncio
+    async def test_a_refused_decision_is_recorded_too(self) -> None:
+        """The dispute most likely to arrive is about a refusal."""
+        registry = a_registry()
+
+        await connector_with(registry).act(
+            a_decision(ActionType.ACTION_TYPE_REJECT), a_context()
+        )
+
+        assert any(
+            c[0][1] == "record_receipt" for c in registry.execute.await_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_decision_with_no_receipt_records_nothing(self) -> None:
+        """An unwired Membrane mints none; there is nothing to archive."""
+        registry = a_registry()
+        intent = Intent(action=ActionType.ACTION_TYPE_COUNTER, reasoning="x")
+
+        await connector_with(registry).act(intent, a_context())
+
+        assert not any(
+            c[0][1] == "record_receipt" for c in registry.execute.await_args_list
+        )
+
+
+class TestTheArchiveNeverCostsTheDecision:
+    @pytest.mark.asyncio
+    async def test_a_failed_write_still_returns_an_observation(self) -> None:
+        registry = a_registry(Observation(success=False, error="connection refused"))
+
+        observation = await connector_with(registry).act(
+            a_decision(ActionType.ACTION_TYPE_COUNTER), a_context()
+        )
+
+        assert observation is not None
+
+    @pytest.mark.asyncio
+    async def test_a_raising_write_still_returns_an_observation(self) -> None:
+        """
+        The promise has to hold from where the code sits, not from someone
+        having checked that the protein never raises.
+        """
+        registry = MagicMock()
+        registry.execute = AsyncMock(side_effect=RuntimeError("pool exhausted"))
+
+        observation = await connector_with(registry).act(
+            a_decision(ActionType.ACTION_TYPE_COUNTER), a_context()
+        )
+
+        assert observation is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=core/src:core/gen-proto:packages/aura-core/src:packages/aura-core/gen-proto uv run pytest core/tests/test_receipt_recording.py -v`
+Expected: FAIL — no `record_receipt` call is ever made, so `next(...)` raises `StopIteration` and the fail-open tests error on the registry mock.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `core/src/aura_hive/hive/connector/main.py`, add to `HiveConnector` immediately after `__init__`:
+
+```python
+    async def act(self, action: Intent, context: Context) -> Observation:
+        """
+        Archive the receipt, then act.
+
+        Written here rather than in the Membrane that mints it: this is the
+        step that performs I/O, and putting a Postgres round-trip inside a
+        boundary check would pay negotiation latency for an archive. The
+        Genome's `act` dispatches steps or falls back to `_handle_legacy`, and
+        recording before that delegation means every decision is archived on
+        both paths — including the refusals, which are the disputes most
+        likely to arrive.
+        """
+        await self._record_receipt(action)
+        return await super().act(action, context)
+
+    async def _record_receipt(self, action: Intent) -> None:
+        """
+        Fail-open, deliberately and completely.
+
+        The rule the receipt log line already follows: reporting on a decision
+        must never take that decision down. The cost is that archive holes are
+        possible and silent, which is why the failure is its own event — an
+        archive that sometimes never arrives is worse than one that expires,
+        because nothing announces it.
+        """
+        if not action.receipt or not action.dispute_token:
+            return
+
+        try:
+            observation = await self.registry.execute(
+                "persistence",
+                "record_receipt",
+                {
+                    "receipt": action.receipt.to_dict(),
+                    "dispute_token": action.dispute_token,
+                },
+            )
+            if not observation.success:
+                logger.warning(
+                    "receipt_record_failed",
+                    dispute_token=action.dispute_token,
+                    error=observation.error,
+                )
+        except Exception as e:
+            logger.warning(
+                "receipt_record_failed",
+                dispute_token=action.dispute_token,
+                error=str(e),
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=core/src:core/gen-proto:packages/aura-core/src:packages/aura-core/gen-proto uv run pytest core/tests/test_receipt_recording.py -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Run the whole core suite**
+
+Run: `PYTHONPATH=core/src:core/gen-proto:packages/aura-core/src:packages/aura-core/gen-proto uv run pytest core/tests/ -q`
+Expected: all pass. `HiveConnector.act` is now on the path of every connector test; if one breaks, its registry mock is returning something the recording path cannot read — fix the mock, not the fail-open guarantee.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+make lint
+git add core/src/aura_hive/hive/connector/main.py core/tests/test_receipt_recording.py
+git commit -m "feat(connector): archive every receipt, including the refusals"
+```
+
+---
+
+### Task 4: The auditor's command
+
+**Files:**
+- Create: `tools/resolve_dispute.py`
+- Modify: `Makefile` (add a target beside `verify-receipts` at line ~203)
+- Test: `core/tests/test_resolve_dispute_tool.py`
+
+**Interfaces:**
+- Consumes: `find_receipt_by_dispute_token` from Task 2.
+- Produces: `resolve(receipt_dict) -> tuple[str, int]` — the printable report and the exit code.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/tests/test_resolve_dispute_tool.py`:
+
+```python
+"""
+What an auditor gets when a counterparty cites a token.
+
+Not just the document: the document plus whether it holds up. In a dispute the
+second question is the one being asked.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+from resolve_dispute import render  # noqa: E402
+
+
+def an_unsigned_receipt() -> dict:
+    return {
+        "version": "AURA-RECEIPT-V2-UNSIGNED",
+        "claimHash": "a" * 64,
+        "emissionHash": "a" * 64,
+        "outcome": "DECISION_OUTCOME_EMIT",
+        "canonicalPrefix": "c" * 16,
+        "issuedAt": "2026-08-12T10:00:00Z",
+        "decisionId": "dec-1111",
+        "requestId": "req-2222",
+        "rulesetVersion": "guard/negotiation@2.0.0+deadbeef",
+    }
+
+
+def test_a_found_receipt_is_reported_with_its_verdict() -> None:
+    report, code = render(an_unsigned_receipt())
+
+    assert "dec-1111" in report
+    assert "req-2222" in report
+    assert "verify" in report.lower()
+    assert code == 0
+
+
+def test_an_unsigned_receipt_is_named_as_unattested() -> None:
+    """
+    The auditor must not read "verified" as "vouched for". §7 keeps the two
+    version names apart precisely so this distinction survives.
+    """
+    report, _ = render(an_unsigned_receipt())
+
+    assert "not attested" in report.lower()
+
+
+def test_a_missing_receipt_is_an_answer_not_a_failure() -> None:
+    """
+    A token that was never issued is a legitimate thing to tell an auditor.
+    Exit 0, because the tool answered.
+    """
+    report, code = render(None)
+
+    assert "not found" in report.lower()
+    assert code == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=core/src:core/gen-proto:packages/aura-core/src:packages/aura-core/gen-proto uv run pytest core/tests/test_resolve_dispute_tool.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'resolve_dispute'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `tools/resolve_dispute.py`:
+
+```python
+"""
+Resolve a dispute token into the receipt it names, and say whether it holds.
+
+`make resolve-dispute TOKEN=…`
+
+The counterparty holds a random per-decision token and nothing else — no
+digest, no prefix, nothing derived from the decision (§3.4). This is the tool
+that turns that citation into the decision an auditor can read.
+
+The query itself lives in the persistence protein rather than here, so an
+internal endpoint later is a second thin caller rather than a second
+implementation.
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+from aura_core_gen.aura.core.v1 import DecisionReceipt
+from aura_hive.config import get_settings
+from aura_hive.hive.cortex import HiveCell
+from aura_hive.hive.membrane.receipt import verify
+
+
+def render(receipt: dict[str, Any] | None) -> tuple[str, int]:
+    """
+    The report and the exit code.
+
+    A token nobody issued is an answer rather than a fault, so it exits 0. The
+    tool failing to reach the database is a different thing and exits non-zero
+    — that is the tool not answering, handled by the caller below.
+    """
+    if receipt is None:
+        return ("not found — no decision was recorded under that token", 0)
+
+    parsed = DecisionReceipt().from_dict(receipt)
+    result = verify(parsed)
+
+    lines = [
+        f"decision_id    {parsed.decision_id}",
+        f"request_id     {parsed.request_id}",
+        f"issued_at      {parsed.issued_at}",
+        f"outcome        {parsed.outcome}",
+        f"outcome_gate   {parsed.outcome_gate or '—'}",
+        f"override_scope {parsed.override_scope or '—'}",
+        f"claim_hash     {parsed.claim_hash}",
+        f"emission_hash  {parsed.emission_hash}",
+        "",
+        f"verify         {'ok' if result.ok else 'FAILED'}",
+        f"               {'attested' if result.attested else 'not attested'}",
+    ]
+    for failure in result.failures:
+        lines.append(f"  failure      {failure}")
+    if result.unverifiable:
+        lines.append(f"  unverifiable {', '.join(result.unverifiable)}")
+    lines.append("")
+    lines.append(json.dumps(receipt, indent=2, sort_keys=True))
+
+    return ("\n".join(lines), 0 if result.ok else 1)
+
+
+async def _lookup(token: str) -> dict[str, Any] | None:
+    cell = HiveCell(get_settings())
+    await cell._init_proteins()
+    observation = await cell.registry.execute(
+        "persistence", "find_receipt_by_dispute_token", {"dispute_token": token}
+    )
+    if not observation.success:
+        if observation.error == "not_found":
+            return None
+        raise RuntimeError(observation.error)
+    meta = observation.metadata.to_dict() if observation.metadata else {}
+    return dict(meta.get("receipt") or {})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("token", help="the dispute_token the counterparty cited")
+    args = parser.parse_args()
+
+    try:
+        receipt = asyncio.run(_lookup(args.token))
+    except Exception as e:
+        print(f"could not reach the archive: {e}", file=sys.stderr)
+        return 2
+
+    report, code = render(receipt)
+    print(report)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+In the `Makefile`, add beside `verify-receipts`:
+
+```makefile
+resolve-dispute:
+	# Resolve a dispute token into the receipt it names (TOKEN=<uuid>)
+	PYTHONPATH=$(TOOL_PATH):$(CORE_PATH) uv run python tools/resolve_dispute.py $(TOKEN)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=core/src:core/gen-proto:packages/aura-core/src:packages/aura-core/gen-proto uv run pytest core/tests/test_resolve_dispute_tool.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: End-to-end check by hand**
+
+The tool needs a live database, so this is a manual step rather than a test.
+With Postgres up (`docker compose up -d db`), run a negotiation, take the
+`dispute_token` from the response, and:
+
+```bash
+make resolve-dispute TOKEN=<the token>
+```
+
+Expected: the receipt prints with `verify ok`. An invented token prints
+`not found` and exits 0.
+
+- [ ] **Step 6: Run the whole core suite and lint**
+
+```bash
+PYTHONPATH=core/src:core/gen-proto:packages/aura-core/src:packages/aura-core/gen-proto uv run pytest core/tests/ -q
+make lint
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/resolve_dispute.py Makefile core/tests/test_resolve_dispute_tool.py
+git commit -m "feat(tools): turn a cited dispute token into a verified receipt"
+```
+
+---
+
+### Task 5: Say in the docs what is now true
+
+**Files:**
+- Modify: `docs/DECISION_RECEIPT.md` (§7 "Who actually reads one" — the paragraph beginning "The auditor's copy comes from the log")
+
+**Interfaces:**
+- Consumes: everything above. Produces no code interface.
+
+- [ ] **Step 1: Correct the claim**
+
+§7 currently says "The log line makes the log the store." That was true and is
+now half the story — and the half it omits is the one that made this work
+necessary. Replace the paragraph beginning "**This is the consumer that was
+missing when step 6 was written off as unbuildable**" with:
+
+```markdown
+**This is the consumer that was missing when step 6 was written off as unbuildable** (§6). The
+verifier had existed since the receipt did and ran only in tests, because no receipt was persisted
+anywhere. The log line makes the log *a* store, and the tool makes it read.
+
+**The log is not the durable store, and treating it as one was the gap.** It goes to a Loki outside
+this repository whose retention is measured in days to weeks, so a dispute arriving a month after the
+decision found nothing — the receipt had expired, signature and all. Every decision is now also
+written to `decision_receipts` by the Connector on the C step, keyed by `dispute_token`, and
+`make resolve-dispute TOKEN=…` turns a counterparty's citation into the receipt plus its verdict.
+
+The write is fail-open, like the log line and for the same reason: reporting on a decision must never
+take that decision down. The cost is that archive holes are possible and silent, so a failure emits
+`receipt_record_failed` as its own event — an archive that sometimes never arrives is worse than one
+that expires, because nothing announces it. The log line stays as an independent second path.
+```
+
+- [ ] **Step 2: Check nothing else still calls the log the store**
+
+Run: `grep -n "the log the store\|log is the store" docs/DECISION_RECEIPT.md`
+Expected: only the corrected passage. Fix any other occurrence the same way.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/DECISION_RECEIPT.md
+git commit -m "docs: the log was never the durable store"
+```

--- a/docs/superpowers/plans/2026-08-12-receipt-durability.md
+++ b/docs/superpowers/plans/2026-08-12-receipt-durability.md
@@ -672,8 +672,13 @@ Expected: FAIL — no `record_receipt` call is ever made, so `next(...)` raises 
 
 In `core/src/aura_hive/hive/connector/main.py`, add to `HiveConnector` immediately after `__init__`:
 
+Note the parameter types: `BaseConnector.act` is declared `(action: Any, context: Any)`, so the
+override must not narrow them to `Intent`/`Context` — mypy rejects that as a Liskov violation and
+`make lint` will refuse the commit. `_record_receipt` takes the narrow type, since nothing overrides
+it.
+
 ```python
-    async def act(self, action: Intent, context: Context) -> Observation:
+    async def act(self, action: Any, context: Any) -> Observation:
         """
         Archive the receipt, then act.
 

--- a/docs/superpowers/specs/2026-08-12-receipt-durability-design.md
+++ b/docs/superpowers/specs/2026-08-12-receipt-durability-design.md
@@ -1,0 +1,166 @@
+# Receipt durability and dispute lookup — design
+
+**Status:** approved, not implemented
+**Date:** 2026-08-12
+**Follows:** `2026-08-12-attestation-protein-design.md`, `2026-08-11-decision-receipt-v2-design.md`
+
+## Why
+
+**The corpus does not survive.**
+
+`docs/DECISION_RECEIPT.md` §7 says "the log line makes the log the store". It does — for days to
+weeks. `membrane_receipt` goes to Loki, which lives in the `monitoring` namespace outside this
+repository and retains for a short window. Nothing writes a receipt anywhere else:
+`grep -rn "receipt" core/src/aura_hive/hive/proteins/persistence/` finds nothing.
+
+So a dispute arriving a month after the decision finds nothing to resolve, and the branch that
+taught the Hive to sign its receipts bought a corpus that evaporates before a consumer can read it.
+
+This is the same time-shape that justified the attestation work and it applies harder here. A
+receipt minted unsigned is permanently unattestable; a receipt that expires is permanently gone.
+Neither can be repaired later. A lookup API, by contrast, can be built at any time over data that
+still exists — which is why **durability is the work and the resolver falls out of it**, rather than
+the other way round.
+
+## What this is not
+
+There is no dispute process yet, and no counterparty has ever cited a token. This design does not
+build a public endpoint, an authorisation model, a dispute workflow, or a retention policy. It makes
+receipts stop disappearing, and gives the auditor one command.
+
+The lookup deliberately lives in the persistence protein rather than in the tool, so that an internal
+endpoint later is a second thin caller rather than a rewrite. That is the only concession to a future
+that may not arrive, and it costs nothing today.
+
+## Decisions
+
+**The Connector writes, on the C step.** Considered and rejected: (a) the Membrane writing where it
+mints — it is the single funnel every receipt passes through, which is attractive, but it puts a
+Postgres round-trip inside a boundary check on the decision path; the Membrane performs exactly one
+synchronous call today, to the guard, and paying negotiation latency for an archive is the wrong
+trade; (b) a separate consumer tailing the log — full decoupling and nothing added to the hot path,
+but it adds a deployable moving part and, fatally, builds the archive on top of the very
+short-retention stream this design exists to escape.
+
+The Connector is the "act" step, already holds the persistence protein, and already copies
+`dispute_token` onto the observation. `MetabolicLoop` calls `connector.act` unconditionally after
+the outbound Membrane (`metabolism/main.py:74`), so **refused decisions reach it too** — which
+matters, because "you refused me" is exactly the dispute a counterparty brings.
+
+**The write is fail-open.** A failure logs and is swallowed; the decision proceeds. This is the rule
+the receipt log line already follows and states: reporting on a decision must never take that
+decision down.
+
+**The log line stays.** Two independent paths, not a replacement. The log survives Postgres being
+unreachable and costs nothing extra.
+
+**No retention policy, no cleanup job.** A receipt is digests and identifiers — on the order of a
+kilobyte — so a million decisions is about a gigabyte. Deleting the archive on a timer is precisely
+the disease being cured. The growth is unbounded and this document says so on purpose; revisit when
+the table is large enough to measure, not before.
+
+## Architecture
+
+```
+MetabolicLoop
+  └─ connector.act(decision, context)          ← already called for every decision
+       └─ registry.execute("persistence", "record_receipt", {...})   [fail-open]
+            └─ ReceiptRepository.record(...)
+
+tools/resolve_dispute.py   (make resolve-dispute TOKEN=…)
+  └─ registry.execute("persistence", "find_receipt_by_dispute_token", {...})
+       └─ ReceiptRepository.find_by_dispute_token(...)
+            └─ verify() over what came back
+```
+
+### Storage
+
+A `DecisionReceiptRecord` model in `persistence/engine.py`, beside `InventoryItem` and `LockedDeal`,
+following the same `DeclarativeBase` / `Mapped[...]` pattern.
+
+| column | type | note |
+|---|---|---|
+| `dispute_token` | `String`, unique index | what the counterparty cites; the lookup key |
+| `decision_id` | `String`, index | what the signature binds; the auditor's other way in |
+| `request_id` | `String`, index | the session, for reassembling a negotiation |
+| `issued_at` | `String` | the receipt's own timestamp, not the write's — stored as the string the receipt carries rather than parsed into a `DateTime`, so the column holds what was signed rather than a reconstruction of it |
+| `receipt` | `JSONB` | the whole document, exactly as logged |
+| `recorded_at` | `DateTime` | when the row was written |
+
+**The receipt is stored whole rather than decomposed.** `verify()` takes a document, and every
+normalisation is an opportunity to reassemble something at read time that differs from what was
+signed. The indexed columns are duplicated out of the JSON for lookup only; the JSON is the record.
+
+**Nothing here leaks.** §7 already establishes it: no field of `DecisionReceipt`,
+`DecisionDerivation` or `ReceiptSignature` is a price or a premise value — every one is a digest, an
+identifier, an enum, a timestamp, or signature metadata. The table does not become a new place where
+`floor_price` lives.
+
+### Components
+
+**`ReceiptRepository`** (`persistence/receipts.py`) — one file beside `deals.py`, `items.py`,
+`wallet.py`. Two methods: `record(receipt_dict, dispute_token)` and
+`find_by_dispute_token(token) -> dict | None`.
+
+**Two new persistence capabilities** (`persistence/skill.py`), added to the `_capabilities` map
+alongside the existing ones:
+
+- `record_receipt` takes `{"receipt": dict, "dispute_token": str}` — the receipt as
+  `decision.receipt.to_dict()`, which is the same rendering the log line carries. The skill derives
+  `decision_id`, `request_id` and `issued_at` from the receipt dict rather than accepting them
+  separately, so the indexed columns cannot disagree with the document they index. Returns
+  `Observation(success=True)`, or a failed Observation carrying the error.
+- `find_receipt_by_dispute_token` takes `{"dispute_token": str}` and returns
+  `Observation(success=True, metadata={"receipt": …})` when found, or `Observation(success=False,
+  error="not_found")`. Absence is a normal answer, so it is not an exception.
+
+**`tools/resolve_dispute.py`**, wired as `make resolve-dispute TOKEN=…` beside `verify-receipts`.
+Finds, runs `verify()`, prints the receipt and the verdict.
+
+## Error handling
+
+**Recording:** any exception is caught at the Connector, logged as `receipt_record_failed` with the
+`dispute_token`, and the decision proceeds untouched.
+
+The gap this leaves is worth stating rather than discovering: **fail-open means archive holes are
+possible and silent.** `receipt_record_failed` is a distinct event precisely so it can carry an
+alert — otherwise this design replaces "the data disappears after a week" with "the data sometimes
+never arrives", which is worse because nothing announces it. The log line remains as the second path,
+so a failed write is not automatically a lost receipt.
+
+**Resolving:** an unknown token prints "not found" and exits **0**. A token that was never issued is
+a legitimate answer to give an auditor — someone may have invented it — not a tool failure. A
+database that cannot be reached exits non-zero, because that is the tool failing rather than
+answering.
+
+## Testing
+
+- **A recorded receipt is found by its token**, driven through the protein against a real session,
+  as the existing repository tests do.
+- **A refused decision is recorded too.** This is the case the Connector-writes decision was checked
+  against; a dispute about a refusal is the likeliest dispute there is.
+- **A database failure does not cost the decision:** the observation still returns, and
+  `receipt_record_failed` is logged.
+- **A receipt still verifies after the round trip through Postgres.** The single most important test
+  here: JSON serialisation must not disturb a signed document. If this fails the archive is
+  decorative.
+- **An unknown token reports not-found and exits 0.**
+- **Two decisions in one session** both resolve, and share a `request_id` — the field exists for
+  reassembly and nothing else asserts it.
+
+## Risks
+
+**Silent archive holes**, as above. Mitigated by a distinct failure event and by the log line
+remaining; not eliminated.
+
+**Unbounded growth**, accepted deliberately and documented rather than solved.
+
+**Write amplification on the decision path.** One insert per decision, on a path that already does a
+guard round-trip and a log write. If it ever shows up in latency, the answer is to move the write off
+the request path (a queue, or the log-tailing consumer rejected above) rather than to drop it.
+
+## Out of scope
+
+The internal or public endpoint, its authorisation model, and any revisit of §1.1's decision that
+the reader is an auditor. The §3.4 residual (`proposed_price` in the response, the jitter bound
+decaying with N). Backfilling receipts that have already expired — they are gone, which is the point.

--- a/docs/superpowers/specs/2026-08-12-receipt-durability-design.md
+++ b/docs/superpowers/specs/2026-08-12-receipt-durability-design.md
@@ -135,15 +135,26 @@ answering.
 
 ## Testing
 
-- **A recorded receipt is found by its token**, driven through the protein against a real session,
-  as the existing repository tests do.
+**All of these run against `MagicMock` sessions, in the style of the existing repository tests
+(`test_persistence_wallet.py`). SQLAlchemy itself never executes.** That is worth stating plainly
+rather than implying otherwise: no test here could catch a JSONB type error, a broken column default,
+or an index that fails to create. The live path was verified by hand against a Postgres 16 container
+during review — table creation reached through `cortex.py` → `post_initialize` → `create_all`, a real
+minted receipt round-tripping byte-identical including the `\x1f` separators in `gateSequence`, and
+`verify()` returning ok and attested on what came back — but verified by hand is not verified by the
+suite. A Postgres-marked integration test is the honest follow-up.
+
+- **A recorded receipt is found by its token**, driven through the protein.
 - **A refused decision is recorded too.** This is the case the Connector-writes decision was checked
   against; a dispute about a refusal is the likeliest dispute there is.
 - **A database failure does not cost the decision:** the observation still returns, and
   `receipt_record_failed` is logged.
-- **A receipt still verifies after the round trip through Postgres.** The single most important test
-  here: JSON serialisation must not disturb a signed document. If this fails the archive is
-  decorative.
+- **A receipt survives JSON and still parses.** The property the archive rests on — serialisation
+  must not disturb a signed document. Note what this test is and is not: it runs `json.dumps` /
+  `json.loads` over the stored dict, which is the risk that lives in the code under test. It does
+  **not** go through Postgres, and a hand-built dict cannot exercise `verify()` at all, because
+  `canonical_prefix` is a digest of the content fields and an invented one fails for reasons
+  unrelated to storage. The end-to-end version of this claim was established by hand, above.
 - **An unknown token reports not-found and exits 0.**
 - **Two decisions in one session** both resolve, and share a `request_id` — the field exists for
   reassembly and nothing else asserts it.

--- a/tools/resolve_dispute.py
+++ b/tools/resolve_dispute.py
@@ -1,0 +1,95 @@
+"""
+Resolve a dispute token into the receipt it names, and say whether it holds.
+
+`make resolve-dispute TOKEN=…`
+
+The counterparty holds a random per-decision token and nothing else — no
+digest, no prefix, nothing derived from the decision (§3.4). This is the tool
+that turns that citation into the decision an auditor can read.
+
+The query itself lives in the persistence protein rather than here, so an
+internal endpoint later is a second thin caller rather than a second
+implementation.
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+from aura_core_gen.aura.core.v1 import DecisionReceipt
+from aura_hive.config import get_settings
+from aura_hive.hive.cortex import HiveCell
+from aura_hive.hive.membrane.receipt import verify
+
+
+def render(receipt: dict[str, Any] | None) -> tuple[str, int]:
+    """
+    The report and the exit code.
+
+    A token nobody issued is an answer rather than a fault, so it exits 0. The
+    tool failing to reach the database is a different thing and exits non-zero
+    — that is the tool not answering, handled by the caller below.
+    """
+    if receipt is None:
+        return ("not found — no decision was recorded under that token", 0)
+
+    parsed = DecisionReceipt().from_dict(receipt)
+    result = verify(parsed)
+
+    lines = [
+        f"decision_id    {parsed.decision_id}",
+        f"request_id     {parsed.request_id}",
+        f"issued_at      {parsed.issued_at}",
+        f"outcome        {parsed.outcome}",
+        f"outcome_gate   {parsed.outcome_gate or '—'}",
+        f"override_scope {parsed.override_scope or '—'}",
+        f"claim_hash     {parsed.claim_hash}",
+        f"emission_hash  {parsed.emission_hash}",
+        "",
+        f"verify         {'ok' if result.ok else 'FAILED'}",
+        f"               {'attested' if result.attested else 'not attested'}",
+    ]
+    for failure in result.failures:
+        lines.append(f"  failure      {failure}")
+    if result.unverifiable:
+        lines.append(f"  unverifiable {', '.join(result.unverifiable)}")
+    lines.append("")
+    lines.append(json.dumps(receipt, indent=2, sort_keys=True))
+
+    return ("\n".join(lines), 0 if result.ok else 1)
+
+
+async def _lookup(token: str) -> dict[str, Any] | None:
+    cell = HiveCell(get_settings())
+    await cell._init_proteins()
+    observation = await cell.registry.execute(
+        "persistence", "find_receipt_by_dispute_token", {"dispute_token": token}
+    )
+    if not observation.success:
+        if observation.error == "not_found":
+            return None
+        raise RuntimeError(observation.error)
+    meta = observation.metadata.to_dict() if observation.metadata else {}
+    return dict(meta.get("receipt") or {})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("token", help="the dispute_token the counterparty cited")
+    args = parser.parse_args()
+
+    try:
+        receipt = asyncio.run(_lookup(args.token))
+    except Exception as e:
+        print(f"could not reach the archive: {e}", file=sys.stderr)
+        return 2
+
+    report, code = render(receipt)
+    print(report)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/resolve_dispute.py
+++ b/tools/resolve_dispute.py
@@ -20,8 +20,10 @@ from typing import Any
 
 from aura_core_gen.aura.core.v1 import DecisionReceipt
 from aura_hive.config import get_settings
-from aura_hive.hive.cortex import HiveCell
 from aura_hive.hive.membrane.receipt import verify
+from aura_hive.hive.proteins.persistence.skill import PersistenceSkill
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 
 def render(receipt: dict[str, Any] | None) -> tuple[str, int]:
@@ -62,10 +64,30 @@ def render(receipt: dict[str, Any] | None) -> tuple[str, int]:
 
 
 async def _lookup(token: str) -> dict[str, Any] | None:
-    cell = HiveCell(get_settings())
-    await cell._init_proteins()
-    observation = await cell.registry.execute(
-        "persistence", "find_receipt_by_dispute_token", {"dispute_token": token}
+    """
+    One protein, one connection, no cell.
+
+    Booting a `HiveCell` was the short way to reach the persistence protein and
+    it was wrong in a way that matters for an audit tool: `_init_proteins` runs
+    `post_initialize`, which runs `Base.metadata.create_all`. So the first run
+    of this command against a deployment whose archive had never worked would
+    have silently created the empty table and then reported "not found" — and
+    "the token was never issued" and "the archive was never running" are
+    exactly the two answers an auditor must be able to tell apart. The second
+    is the finding.
+
+    Binding without `initialize()` is deliberate and sufficient: `execute`
+    checks only that a provider is bound, so the lookup needs neither the Redis
+    ping nor NATS nor an embedding model — none of which a SELECT has any
+    business requiring.
+    """
+    settings = get_settings()
+    engine = create_engine(str(settings.database.url))
+    protein = PersistenceSkill()
+    protein.bind(settings.database, (sessionmaker(bind=engine), engine, None))
+
+    observation = await protein.execute(
+        "find_receipt_by_dispute_token", {"dispute_token": token}
     )
     if not observation.success:
         if observation.error == "not_found":

--- a/tools/resolve_dispute.py
+++ b/tools/resolve_dispute.py
@@ -72,7 +72,12 @@ async def _lookup(token: str) -> dict[str, Any] | None:
             return None
         raise RuntimeError(observation.error)
     meta = observation.metadata.to_dict() if observation.metadata else {}
-    return dict(meta.get("receipt") or {})
+    receipt = meta.get("receipt")
+    # An empty payload reads as "not found" rather than as a receipt.
+    # Returning `{}` here would hand `render` an empty document, which then
+    # reports a verification failure — telling an auditor the record is broken
+    # when what actually happened is that nothing came back.
+    return dict(receipt) if receipt else None
 
 
 def main() -> int:


### PR DESCRIPTION
## The problem

**The corpus does not survive.**

`docs/DECISION_RECEIPT.md` §7 said "the log line makes the log the store". It made the log *a* store: `membrane_receipt` goes to a Loki that lives in the `monitoring` namespace outside this repository, with a retention measured in days to weeks. Nothing wrote a receipt anywhere else — `grep -rn "receipt" core/src/aura_hive/hive/proteins/persistence/` found nothing.

So a dispute arriving a month after the decision found nothing to resolve, and the branch that taught the Hive to sign its receipts (#280) bought a corpus that evaporates before a consumer can read it.

§6 said the same thing and then, two sentences later, that "storing receipts properly is still open". Both were written in the same breath and the first quietly undid the second. That is the sentence that let the gap sit unnoticed.

## Why this is not the resolver that was asked for

The request was a `dispute_token` resolver. The resolver is not the urgent half: a lookup can be built at any time over data that still exists, while an expired receipt is gone the same way an unsigned one is permanently unattestable. Neither can be repaired later.

So durability is the work, and the resolver falls out of it as a query on a table that now exists.

## What this does

```
MetabolicLoop
  └─ connector.act(decision, context)          ← already called for every decision
       └─ registry.execute("persistence", "record_receipt", …)   [fail-open]
            └─ ReceiptRepository.record(…)

make resolve-dispute TOKEN=…
  └─ registry.execute("persistence", "find_receipt_by_dispute_token", …)
       └─ verify() over what came back
```

**The Connector writes, on the C step.** `MetabolicLoop` calls `connector.act` unconditionally after the outbound Membrane, so **refused decisions are recorded too** — and "you refused me" is the likeliest dispute a counterparty brings.

Rejected: the Membrane writing where it mints, which puts a Postgres round-trip inside a boundary check on the decision path (it performs exactly one synchronous call today, to the guard); and a log-tailing consumer, which builds the archive on top of the very short-retention stream this exists to escape.

**The whole document is stored, not decomposed.** `verify()` takes a document, and every normalisation is a chance to reassemble something at read time that differs from what was signed. The indexed columns are derived *from* the JSON rather than passed in beside it, so an index cannot come to disagree with the receipt it indexes.

**The lookup lives in the protein, not the tool** — so the internal endpoint this defers is a second thin caller rather than a second implementation.

**Nothing leaks.** §7 already establishes it: no field of `DecisionReceipt`, `DecisionDerivation` or `ReceiptSignature` is a price or a premise value. The table does not become a new place `floor_price` lives.

## The gap this leaves, stated rather than discovered

The write is fail-open — reporting on a decision must never take that decision down. The cost is that **archive holes are possible and silent**, so a failure emits `receipt_record_failed` as its own event, ready for an alert. Otherwise this trades "the data disappears after a week" for "the data sometimes never arrives", which is worse because nothing announces it. The log line stays as an independent second path and survives Postgres being unreachable.

Growth is unbounded and there is no cleanup job. A receipt is about a kilobyte, so a million decisions is about a gigabyte, and deleting the archive on a timer is precisely the disease being cured. Revisit when the table is large enough to measure.

## Verification

| | |
|---|---|
| core | 631 passed (610 before) |
| api-gateway / telegram-bot / bee-keeper / bee-evolver / mcp-server | 7 / 6 / 7 / 33 / 14 |
| `make lint` | exit 0 |

`make test` exits 2 on `packages/aura-worker` (`ModuleNotFoundError: typer`) — pre-existing, documented, untouched.

**Not verified: the live database path.** `record()` and `find_by_dispute_token()` are tested against mock sessions, in the style of the existing persistence tests. The JSONB column, the unique index, and schema creation have not been exercised against a real Postgres. That is the first thing to check by hand:

```bash
docker compose up -d db
# run a negotiation, take dispute_token from the response
make resolve-dispute TOKEN=<the token>
```

## Where the plan was wrong

- The plan's test fixture was a hand-written receipt asserted to verify. It cannot: `canonical_prefix` is a digest of the content fields, so an invented one fails for a reason unrelated to what was under test — the assertion would have measured the fixture's invalidity. The test now mints a receipt through a real Membrane, which also exercises the `to_dict()` → render path the archive uses, and gained a tampered-receipt case.
- The plan's `act` override narrowed parameter types to `Intent`/`Context`, which mypy rejects as a Liskov violation against the Genome's `(Any, Any)`. Caught before starting.
- The plan warned that `act` on every connector test's path would break mocks. It did not: the early return on a missing receipt or token means an Intent without them never starts a write.

## Follow-ups, not in scope

The internal endpoint and its authorisation model; §3.4's residual (`proposed_price` in the response, the jitter bound decaying with N); #279. Receipts that have already expired are gone — that is the point.

Spec: `docs/superpowers/specs/2026-08-12-receipt-durability-design.md`
Plan: `docs/superpowers/plans/2026-08-12-receipt-durability.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
