### PR TITLE
docs: the floor bound was measured on the wrong channel

### DIFF
--- a/docs/DECISION_RECEIPT.md
+++ b/docs/DECISION_RECEIPT.md
@@ -391,22 +391,27 @@ that no rule set declares, so they cannot be recorded as gates without inventing
 
 #### The leak this field closes, and the one it does not
 
-**"You cannot probe it for the floor" holds for this field and not for the channel, and an earlier
-draft of this document ran the two together.** The derivation is clean. The counter-offer beside it
-is not: when a gate fires, the Membrane substitutes `safe_offer(context)`, and that price is a
-function of the hidden floor. It reaches the counterparty as `proposed_price` on every counter,
-whatever a receipt does or does not say. No amount of trimming the receipt touches it.
+**"You cannot probe it for the floor" holds for this field and not for the response around it, and
+an earlier draft of this document ran the two together.** The derivation is clean. Two channels
+beside it are not, and they are bounded very differently: the **counter-offer**, which is jittered,
+and the **accept/reject decision**, which is not and cannot be. The first is treated below; the
+second gets its own subsection because it is exact, and because measuring the first and reporting
+the answer as the system's bound is the mistake this section previously made.
 
-What V2 does about it is bound the disclosure, not close it:
+The counter-offer channel first. When a gate fires, the Membrane substitutes `safe_offer(context)`,
+and that price is a function of the hidden floor. It reaches the counterparty as `proposed_price` on
+every counter, whatever a receipt does or does not say. No amount of trimming the receipt touches
+it. What V2 does about it is bound the disclosure, not close it:
 
 - **Per-session jitter.** `safe_offer` multiplies by `(1 + j)` before rounding up, where
   `j = ε · HMAC(process_secret, request_id) / 2²⁵⁶` and `ε = 0.03`. Constant within a session, so
   repeated rounds within one negotiation cannot average it away. **Across sessions it decays to
   nothing, and an earlier draft of this bullet claimed the opposite.** Independent draws per session
   are exactly what a corpus averages out: the standard error of the mean over `N` observations is
-  `base · ε / √(12N)`, about **0.09% of the base at `N = 100`**. So the real bound is 3% per
-  observation against a counterparty who sees one, decaying toward zero against a repeat
-  counterparty on the same item. `(1 + j) ≥ 1` and the rounding is a ceiling, so jitter cannot push
+  `base · ε / √(12N)`, about **0.09% of the base at `N = 100`**. So this channel bounds disclosure at
+  3% per observation against a counterparty who sees one, decaying toward zero against a repeat
+  counterparty on the same item — and the accept/reject channel below bounds nothing at all, which
+  is why neither figure is the bound on the floor. `(1 + j) ≥ 1` and the rounding is a ceiling, so jitter cannot push
   a price through ψ. The
   secret is process-lifetime random rather than configured — nothing needs to reproduce the price,
   because ψ checks the value, which is the whole reason ψ is executable (§3.8). An empty `request_id`
@@ -416,9 +421,10 @@ What V2 does about it is bound the disclosure, not close it:
   limit for this item. My best offer is $X."` and the DLP block `"I cannot disclose internal pricing
   details."` — each of which announced that a guard had fired. Both now read as an ordinary counter.
 
-**`ε` is a source constant and therefore public, so the counterparty still learns the floor to within
-3%.** That bound holds only because every floor-derived price is born in the guard, which applies the
-markup and the jitter. The rules-based strategy used to break it: with `llm.model == "rule"` a
+**`ε` is a source constant and therefore public, so a counterparty reading counter-offers learns the
+floor to within 3% per observation.** That is a bound on *this channel*, not on the floor — the
+accept/reject channel below is exact, and dominates it. It holds only because every floor-derived
+price is born in the guard, which applies the markup and the jitter. The rules-based strategy used to break it: with `llm.model == "rule"` a
 below-floor bid was countered at `floor_price` exactly, and the message said the number out loud —
 a 0% bound on a path the DLP check could not see, because it scans for the literal token
 `floor_price` rather than for its value. That strategy no longer prices at all; it proposes the bid
@@ -442,14 +448,59 @@ unsigned format on **any** signing failure — so a client polling it read a liv
 transaction protein was reachable — and `receipt: null` versus an object reported whether minting
 had happened at all.
 
+#### The channel none of this bounds
+
+**An acceptance proves the bid was at or above the floor.** `PSI_ABOVE_FLOOR` is
+`emitted_price >= floor_price` (`guard/engine.py`), and ψ runs on every ACCEPT and COUNTER
+(`membrane/main.py`), so a decision to accept at price P cannot leave unless P ≥ floor. On every
+path, by construction.
+
+That makes acceptance an oracle, and it carries no jitter — nor could it, since noise on the
+decision to accept means refusing sales above the floor. A counterparty who can bid and watch for
+acceptance binary-searches:
+
+| item base price | cent-precision values | probes |
+|---|---|---|
+| 100 | 10,000 | 14 |
+| 1,000 | 100,000 | 17 |
+| 10,000 | 1,000,000 | 20 |
+
+`log₂(range ÷ precision)`, and the logarithm is the point: **widening the price range is not a
+defence.** Doubling it costs the adversary one probe.
+
+The oracle is one-sided, which changes what is learned rather than whether. Acceptance implies
+`bid ≥ floor` always. Non-acceptance implies nothing definite on the LLM path — the model may
+counter a bid above the floor for its own reasons — and is exact on the rules path, where
+`bid < floor_price` counters and anything else accepts. So what a counterparty converges on is the
+**infimum of accepted bids**: exactly the floor on the rules path, the floor or higher on the LLM
+path. Either way it is the number they act on.
+
+**This is not a defect and not fixable by trimming the response.** A threshold that decides
+accept/reject is discoverable by probing the threshold — a property of having a reservation price,
+not of this implementation. Note where it comes from: the safety guarantee is what creates the
+proof. "Never emit below the floor" is precisely what makes an acceptance informative.
+
+Three mitigations were considered and none is built. **Rate limiting per (counterparty, item)** is
+the only one that changes anything: it closes nothing — nothing does — but stretches seventeen
+probes over longer than a price stays current. **Stochastic refusal near the floor** would break the
+proof by making acceptance non-deterministic, and is rejected: it costs revenue on honest bids and
+destroys predictability for the buyers the system exists to serve, in order to slow an adversary who
+can simply probe again. And **keying the jitter deterministically** — `HMAC(secret, item ‖
+counterparty)` rather than on `request_id` — would close the averaging attack described above, since
+a constant offset cannot be averaged away; it is recorded here because it is the obvious fix and it
+addresses the channel that is not the problem. Against a repeat counterparty on one item it buys
+almost nothing: there is no reason to average a hundred observations down to 0.09% when seventeen
+probes give the cent.
+
 So the claim is narrow, and it is not closure:
 
 - **What removal closes:** one-shot recovery, from a single response, of the model's own proposed
   price and of which gate fired. Before, one counter was enough.
-- **What it does not close:** `proposed_price` is still in the response on every counter, so the
-  bound above still holds and still decays with `N`. Timing is a further residual — the override
-  path makes extra registry round-trips, so a patient counterparty can distinguish an overridden
-  counter from an ordinary one without reading a word of it.
+- **What it does not close:** the floor. `proposed_price` is still in the response on every counter,
+  so the 3% bound above still holds and still decays with `N` — and the accept/reject oracle is
+  exact regardless, which is the bound that matters. Timing is a further residual: the override path
+  makes extra registry round-trips, so a patient counterparty can distinguish an overridden counter
+  from an ordinary one without reading a word of it.
 - **What is not lost:** nothing evidential. The counterparty received the prefix *without* the
   signature block, so they could never tell a real receipt from one we invented; it was never
   probative in their hands. `dispute_token` is the handle it was supposed to be — random, per

--- a/docs/superpowers/plans/2026-08-12-floor-disclosure-bound.md
+++ b/docs/superpowers/plans/2026-08-12-floor-disclosure-bound.md
@@ -1,0 +1,204 @@
+# Floor Disclosure Bound Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `docs/DECISION_RECEIPT.md` §3.4 state the bound that actually holds on the floor, instead of a bound that describes one channel and reads as a claim about the system.
+
+**Architecture:** Documentation only. Two passages in §3.4 are amended and one follow-up issue is filed. No source file changes, no tests — there is no behaviour change to test, and adding one would assert that the document says something, which is what review is for.
+
+**Tech Stack:** Markdown. `gh` for the issue.
+
+**Spec:** `docs/superpowers/specs/2026-08-12-floor-disclosure-bound-design.md`
+
+## Global Constraints
+
+- **No source changes.** If this plan makes you want to edit a `.py` file, stop and re-read the spec: closing the channel was considered and is not possible, and the two rejected mitigations are named there with reasons.
+- Facts to preserve exactly, all verified against the code before this plan was written:
+  - `PSI_ABOVE_FLOOR` is `emitted_price >= floor_price` — `core/src/aura_hive/hive/proteins/guard/engine.py:359-360`.
+  - ψ runs on every ACCEPT and COUNTER — `core/src/aura_hive/hive/membrane/main.py:920-923`.
+  - The rules path accepts iff `bid >= floor_price` — `core/src/aura_hive/hive/transformer/main.py:107,118`.
+  - Probe counts: 14 for a base of 100, **17 for 1,000**, 20 for 10,000, at cent precision.
+- The existing 3% figure and the `base · ε / √(12N)` decay are **correct** and stay. They are being scoped to the counter-offer channel, not deleted.
+- `make lint` must exit 0 before the commit. It lints Markdown only incidentally, but the repo runs it on everything and a trailing-whitespace hook will reject the commit otherwise.
+
+---
+
+### Task 1: Restate the bound in §3.4
+
+**Files:**
+- Modify: `docs/DECISION_RECEIPT.md` — the sentence at the top of the mitigation list ("**`ε` is a source constant…**"), and the closing list "So the claim is narrow, and it is not closure" at lines 445-456.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing. This is prose.
+
+- [ ] **Step 1: Scope the 3% sentence to its channel**
+
+Find the paragraph beginning:
+
+```
+**`ε` is a source constant and therefore public, so the counterparty still learns the floor to within
+3%.** That bound holds only because every floor-derived price is born in the guard, which applies the
+markup and the jitter.
+```
+
+Replace only its first sentence, keeping the rest of the paragraph (the rules-strategy history and
+the distinguishability note) exactly as it stands:
+
+```markdown
+**`ε` is a source constant and therefore public, so a counterparty reading counter-offers learns the
+floor to within 3% per observation.** That is a bound on *this channel*, not on the floor — the
+accept/reject channel below is exact, and dominates it. It holds only because every floor-derived
+price is born in the guard, which applies the markup and the jitter.
+```
+
+- [ ] **Step 2: Add the oracle subsection**
+
+Immediately **before** the line `So the claim is narrow, and it is not closure:` (line 445), insert:
+
+```markdown
+#### The channel none of this bounds
+
+**An acceptance proves the bid was at or above the floor.** `PSI_ABOVE_FLOOR` is
+`emitted_price >= floor_price` (`guard/engine.py`), and ψ runs on every ACCEPT and COUNTER
+(`membrane/main.py`), so a decision to accept at price P cannot leave unless P ≥ floor. On every
+path, by construction.
+
+That makes acceptance an oracle, and it carries no jitter — nor could it, since noise on the
+decision to accept means refusing sales above the floor. A counterparty who can bid and watch for
+acceptance binary-searches:
+
+| item base price | cent-precision values | probes |
+|---|---|---|
+| 100 | 10,000 | 14 |
+| 1,000 | 100,000 | 17 |
+| 10,000 | 1,000,000 | 20 |
+
+`log₂(range ÷ precision)`, and the logarithm is the point: **widening the price range is not a
+defence.** Doubling it costs the adversary one probe.
+
+The oracle is one-sided, which changes what is learned rather than whether. Acceptance implies
+`bid ≥ floor` always. Non-acceptance implies nothing definite on the LLM path — the model may
+counter a bid above the floor for its own reasons — and is exact on the rules path, where
+`bid < floor_price` counters and anything else accepts. So what a counterparty converges on is the
+**infimum of accepted bids**: exactly the floor on the rules path, the floor or higher on the LLM
+path. Either way it is the number they act on.
+
+**This is not a defect and not fixable by trimming the response.** A threshold that decides
+accept/reject is discoverable by probing the threshold — a property of having a reservation price,
+not of this implementation. Note where it comes from: the safety guarantee is what creates the
+proof. "Never emit below the floor" is precisely what makes an acceptance informative.
+
+Three mitigations were considered and none is built. **Rate limiting per (counterparty, item)** is
+the only one that changes anything: it closes nothing — nothing does — but stretches seventeen
+probes over longer than a price stays current. **Stochastic refusal near the floor** would break the
+proof by making acceptance non-deterministic, and is rejected: it costs revenue on honest bids and
+destroys predictability for the buyers the system exists to serve, in order to slow an adversary who
+can simply probe again. And **keying the jitter deterministically** — `HMAC(secret, item ‖
+counterparty)` rather than on `request_id` — would close the averaging attack described above, since
+a constant offset cannot be averaged away; it is recorded here because it is the obvious fix and it
+addresses the channel that is not the problem. Against a repeat counterparty on one item it buys
+almost nothing: there is no reason to average a hundred observations down to 0.09% when seventeen
+probes give the cent.
+```
+
+- [ ] **Step 3: Correct the closing list**
+
+Anchor on the text, not on a line number — Step 2 inserted a block above it, so every line below has
+moved. Replace the bullet beginning `- **What it does not close:** \`proposed_price\` is still in the
+response` and its three continuation lines with:
+
+```markdown
+- **What it does not close:** the floor. `proposed_price` is still in the response on every counter,
+  so the 3% bound above still holds and still decays with `N` — and the accept/reject oracle is
+  exact regardless, which is the bound that matters. Timing is a further residual: the override path
+  makes extra registry round-trips, so a patient counterparty can distinguish an overridden counter
+  from an ordinary one without reading a word of it.
+```
+
+- [ ] **Step 4: Check nothing else still claims 3% as the system's bound**
+
+Run: `grep -n "within 3%\|to within 3\|3% of the base" docs/DECISION_RECEIPT.md`
+
+Expected: only the sentence amended in Step 1, and the `base · ε / √(12N)` bullet in the mitigation
+list, which describes the counter-offer channel and is correct. If §1.1 or §7 carries a similar
+claim, amend it the same way — scope it to the channel rather than deleting it.
+
+- [ ] **Step 5: Read the amended section end to end**
+
+Not a mechanical check. Read §3.4 from "#### The leak this field closes, and the one it does not"
+through the closing list and confirm it reads as one argument rather than as an old claim with a
+correction stapled on. The section already distinguishes the derivation field from the channel
+around it; the new subsection has to sit inside that structure, not restate it.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+make lint
+git add docs/DECISION_RECEIPT.md
+git commit -m "docs: name the channel that actually bounds the floor"
+```
+
+---
+
+### Task 2: File the probe-cost follow-up
+
+**Files:**
+- None in the repository. This task produces a GitHub issue.
+
+**Interfaces:**
+- Consumes: the amended §3.4 from Task 1, which the issue cites.
+- Produces: an issue number to reference if anyone picks the work up.
+
+- [ ] **Step 1: Write the issue body**
+
+Save to a scratch file and create it with `gh issue create --title "gateway: rate limit probes per (counterparty, item)" --body-file <path>`:
+
+```markdown
+`docs/DECISION_RECEIPT.md` §3.4 now states that acceptance is an exact proof that a bid was at or
+above the floor, so a counterparty who can bid and watch for acceptance binary-searches the floor in
+`log₂(range ÷ precision)` probes — 17 for a base of 1,000 at cent precision.
+
+That channel cannot be closed. A threshold that decides accept/reject is discoverable by probing it,
+and the safety guarantee is what creates the proof: ψ enforces `emitted_price >= floor_price`, so an
+acceptance is informative by construction.
+
+**Rate limiting is the only mitigation that changes the picture.** It does not close the channel —
+it stretches the probes over longer than a price stays current, so the number an adversary recovers
+is stale by the time they have it.
+
+What this needs before it can be built:
+
+- **How long a price is expected to stay valid.** Nobody has this number, and the limit is
+  meaningless without it: a window that outlives the price is free, and one that undercuts honest
+  repeat buyers costs sales.
+- **A decision about honest repeat buyers.** Someone who negotiates the same item weekly is
+  indistinguishable from a slow prober by this signal alone.
+- **Where the counter lives.** The gateway already rate-limits; whether this is another dimension on
+  that or a separate mechanism keyed on `(counterparty, item)` is the design question.
+
+Explicitly rejected in the same section, so it does not get re-proposed: **stochastic refusal near
+the floor.** It would break the proof by making acceptance non-deterministic, at the cost of revenue
+on honest bids and of predictability for the buyers the system exists to serve — to slow an
+adversary who can simply probe again.
+
+Not urgent. Filed so the mitigation is recorded with its open questions rather than remembered as
+"we should rate limit something".
+```
+
+- [ ] **Step 2: Note the issue number in the spec**
+
+Append to the "Recorded, not built" section of
+`docs/superpowers/specs/2026-08-12-floor-disclosure-bound-design.md`, under the **Probe cost**
+paragraph:
+
+```markdown
+Filed as #<the number `gh issue create` printed in Step 1>.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-08-12-floor-disclosure-bound-design.md
+git commit -m "docs(spec): link the probe-cost follow-up"
+```

--- a/docs/superpowers/specs/2026-08-12-floor-disclosure-bound-design.md
+++ b/docs/superpowers/specs/2026-08-12-floor-disclosure-bound-design.md
@@ -1,0 +1,105 @@
+# The floor disclosure bound, restated — design
+
+**Status:** approved, not implemented
+**Date:** 2026-08-12
+**Amends:** `docs/DECISION_RECEIPT.md` §3.4
+**Follows:** `2026-08-12-receipt-durability-design.md`
+
+## Why
+
+§3.4 currently says the counterparty "still learns the floor to within 3%", bounded by the
+per-session jitter on substitute prices. That sentence is true about one channel and false as a
+statement about the system.
+
+**Acceptance is an exact proof that the bid was at or above the floor.** `PSI_ABOVE_FLOOR` is
+`emitted_price >= floor_price` (`guard/engine.py:359-360`), and ψ runs on every ACCEPT and COUNTER
+(`membrane/main.py:920-923`). So a decision to accept at price P cannot be emitted unless P ≥ floor,
+on every path, by construction.
+
+A counterparty who can bid and observe acceptance therefore binary-searches the floor. Jitter does
+nothing about this: it lives in the counter-offer, and the accept/reject channel carries no noise at
+all.
+
+The work is to say so. **No code changes.**
+
+## What this is not
+
+Not a defect, and not fixable by removing fields from the response. A threshold that decides
+accept/reject is discoverable by probing the threshold; that is a property of having a reservation
+price, not of this implementation. It is worth noticing that the safety guarantee is what creates
+the proof: "never emit below the floor" is exactly what makes an acceptance informative.
+
+Not a jitter change either. Deterministic keying — `HMAC(secret, item ‖ counterparty)` instead of
+`HMAC(secret, request_id)` — would close the averaging attack the current text describes, and was
+the obvious fix until the oracle turned up. Against a repeat counterparty on one item it buys almost
+nothing: why average a hundred observations down to 0.09% when seventeen probes give the cent.
+
+## The claim, restated
+
+### The oracle is one-sided, and the asymmetry matters
+
+- **Acceptance ⟹ bid ≥ floor.** Always, every path. ψ enforces it on the emitted value.
+- **Non-acceptance ⟹ nothing definite**, on the LLM path: the model may counter a bid above the
+  floor for its own reasons. On the rules path it is exact — `bid < floor_price` counters and
+  anything else accepts (`transformer/main.py:107,118`).
+
+So what a counterparty converges on is **the infimum of accepted bids**: exactly the floor on the
+rules path, the floor or higher on the LLM path. That is the operative number for them either way —
+arguably more useful than the floor itself.
+
+### The probe count is logarithmic
+
+`log₂(range ÷ precision)`, computed:
+
+| item base price | cent-precision values | probes |
+|---|---|---|
+| 100 | 10,000 | 14 |
+| 1,000 | 100,000 | 17 |
+| 10,000 | 1,000,000 | 20 |
+
+The logarithm is the point: **widening the price range is not a defence.** Doubling it costs the
+adversary one probe.
+
+### Two channels, two bounds
+
+| channel | what it carries | bound |
+|---|---|---|
+| counter-offer (`proposed_price`) | a floor-derived price with markup and jitter | 3% per observation, decaying as `base·ε/√(12N)` |
+| accept / reject | ψ's guarantee, unjittered | exact, in `log₂(range ÷ precision)` probes |
+
+The 3% figure stays in the document, scoped to the channel it describes. It stops being the
+system's bound.
+
+## What the document must stop implying
+
+That trimming the response protects the floor. §7's removal of the receipt closed one-shot recovery
+of the *model's proposed price* and *which gate fired* — a real and different thing, correctly
+described there. It never touched the floor, and §3.4's 3% sentence read as though the two were
+the same defence.
+
+## Recorded, not built
+
+**Probe cost.** Rate limiting per (counterparty, item) is the only mechanism that changes the
+picture: it does not close the channel — nothing does — but it stretches seventeen probes over
+longer than the price stays current. That is its own piece of work in the gateway, and it needs a
+number nobody has yet: how long a price is expected to remain valid.
+
+**Stochastic refusal near the floor** would break the proof by making acceptance non-deterministic.
+Rejected: it costs revenue on honest bids and destroys predictability for the buyers the system
+exists to serve, to slow an adversary who can simply probe more.
+
+## Scope
+
+One passage in `docs/DECISION_RECEIPT.md` §3.4 — the "leak this field closes, and the one it does
+not" subsection — plus a follow-up issue for probe cost. No source file changes, no tests, because
+there is no behaviour change to test.
+
+## Risks
+
+**Writing down an attack.** The document is internal and the arithmetic is elementary; a
+counterparty motivated to probe does not need our notes to think of bidding lower. The cost of not
+writing it down is an operator who reads "within 3%" and prices as though the floor were protected.
+
+**The bound looks worse than before.** It is not — it was always this, and the previous sentence
+measured the wrong channel. Anyone comparing revisions should read this as a correction to the
+claim, not a regression in the system.

--- a/docs/superpowers/specs/2026-08-12-floor-disclosure-bound-design.md
+++ b/docs/superpowers/specs/2026-08-12-floor-disclosure-bound-design.md
@@ -82,7 +82,7 @@ the same defence.
 **Probe cost.** Rate limiting per (counterparty, item) is the only mechanism that changes the
 picture: it does not close the channel — nothing does — but it stretches seventeen probes over
 longer than the price stays current. That is its own piece of work in the gateway, and it needs a
-number nobody has yet: how long a price is expected to remain valid.
+number nobody has yet: how long a price is expected to remain valid. Filed as #283.
 
 **Stochastic refusal near the floor** would break the proof by making acceptance non-deterministic.
 Rejected: it costs revenue on honest bids and destroys predictability for the buyers the system


### PR DESCRIPTION
## The claim that was wrong

§3.4 said the counterparty "still learns the floor to within 3%", bounded by the per-session jitter on substitute prices.

That measures one channel and reads as a statement about the system. **`PSI_ABOVE_FLOOR` is `emitted_price >= floor_price`, and ψ runs on every ACCEPT and COUNTER** — so a decision to accept at price P cannot leave unless P ≥ floor, on every path, by construction.

An acceptance is therefore an exact proof that the bid was at or above the floor, and a counterparty who can bid and watch for acceptance binary-searches it:

| item base price | cent-precision values | probes |
|---|---|---|
| 100 | 10,000 | 14 |
| 1,000 | 100,000 | 17 |
| 10,000 | 1,000,000 | 20 |

`log₂(range ÷ precision)`. The logarithm is the point: **widening the price range is not a defence** — doubling it costs the adversary one probe.

That channel carries no jitter and cannot. Noise on the decision to accept means refusing sales above the floor.

## Why this is documentation and not code

The task began as "close the §3.4 residual". It cannot be closed. A threshold that decides accept/reject is discoverable by probing the threshold — a property of having a reservation price, not of this implementation. Almost ironically, the safety guarantee is what creates the proof: "never emit below the floor" is precisely what makes an acceptance informative.

`proposed_price` cannot be removed either. It is the counter-offer; the counterparty has to receive it or there is no negotiation.

So the deliverable is the claim, restated. **No source changes, no tests** — there is no behaviour change to test.

## What changed in the text

- The 3% figure **stays**, scoped to the counter-offer channel it describes. Same for `base · ε / √(12N)`. Both are correct about their channel; neither is the bound on the floor.
- A new subsection names the accept/reject oracle, gives the arithmetic, and states that the oracle is **one-sided**: acceptance implies `bid ≥ floor` always, while non-acceptance implies nothing definite on the LLM path and is exact on the rules path. What a counterparty converges on is the *infimum of accepted bids* — the floor on the rules path, the floor or higher on the LLM path.
- The closing list stops implying that trimming the response protected the floor. §7's removal of the receipt closed one-shot recovery of the model's proposed price and of which gate fired — real, different, and correctly described there.

## Three mitigations, recorded as unbuilt

- **Rate limiting per (counterparty, item)** — the only one that changes anything. Closes nothing; stretches seventeen probes over longer than a price stays current. Filed as #283 with the open questions that block it, chief among them a number nobody has: how long a price is expected to stay valid.
- **Stochastic refusal near the floor** — would break the proof, at the cost of revenue on honest bids and predictability for the buyers the system serves, to slow an adversary who can simply probe again. Rejected.
- **Deterministic jitter keying** on `(item, counterparty)` rather than `request_id` — would close the averaging attack, and was the obvious fix until the oracle turned up. Recorded because it is what a reader reaches for first, and it addresses the channel that is not the problem.

## Two things the plan did not anticipate

The plan's last step asked for a read-through rather than a check — does the section read as one argument, or as an old claim with a correction stapled on? It caught both of these:

- The subsection opened with "this field and not **the channel**", singular, and then met a second channel further down. Two things called "the channel" is exactly how a correction reads as bolted on. The opening now names both and says why the second gets its own subsection.
- A sentence further up called 3% "the **real** bound", which directly contradicted the new text. Both figures are now scoped to their channel, with the note that neither is the bound on the floor.

## Verification

No code changed. core 634 passed, api-gateway 7, telegram-bot 6, bee-keeper 7, bee-evolver 33, mcp-server 14, `make lint` exit 0 — unchanged from `main`, as expected. `make test` exits 2 on `packages/aura-worker`'s missing `typer`, pre-existing.

## A note on writing an attack down

The document is internal and the arithmetic is elementary — a counterparty motivated to probe does not need our notes to think of bidding lower. The cost of *not* writing it down is an operator who reads "within 3%" and prices as though the floor were protected.

Spec: `docs/superpowers/specs/2026-08-12-floor-disclosure-bound-design.md`
Plan: `docs/superpowers/plans/2026-08-12-floor-disclosure-bound.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
