### PR TITLE
test(make): sync the gateway's own deps instead of borrowing the root's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,14 @@ keeper-audit: $(PROTO_SENTINEL)
 test: $(PROTO_SENTINEL)
 	# Run core tests
 	PYTHONPATH=$(CORE_PATH) uv run pytest core/tests/ -v
-	# Run api-gateway tests (env is provided by api-gateway/tests/conftest.py)
-	PYTHONPATH=$(GATEWAY_PATH) uv run pytest api-gateway/tests/ -v
+	# Run api-gateway tests (env is provided by api-gateway/tests/conftest.py).
+	# Sync the gateway's own declared deps rather than trusting the root env to
+	# happen to carry them: it is a workspace member, not a root dependency, so
+	# `uv sync --group dev` never reaches its declarations, and until something
+	# else stopped pulling python-multipart in nobody could tell. --inexact adds
+	# them to what is already synced; --no-sync stops `uv run` reverting that.
+	uv sync --package api-gateway --inexact
+	PYTHONPATH=$(GATEWAY_PATH) uv run --no-sync pytest api-gateway/tests/ -v
 	# Run telegram-bot tests with isolated path to avoid 'src' collision
 	PYTHONPATH=$(TG_PATH) uv run pytest synapses/telegram-bot/tests/ -v
 	# Run bee.Keeper tests from the root env: its transformer imports dspy, which


### PR DESCRIPTION
Third of three. #285 fixed the Colab worker's import; #286 makes the Gradio panel optional; this one closes the trap that #286 walked into.

## The trap

`api-gateway` is a workspace member, not a dependency of the root project. `uv sync --group dev` therefore never installs what the gateway declares — but its tests run in that root env anyway. It worked only because the root happens to carry most of the same packages, and where it doesn't, something else was supplying them by accident.

`python-multipart` is the case that surfaced. The gateway declares it (`api-gateway/pyproject.toml`), the root does not, and **gradio** was quietly providing it through the root's `aura-worker` dependency. The moment gradio stopped being a hard dependency in #286, two gateway test modules died at collection:

```
RuntimeError: Form data requires "python-multipart" to be installed.
ERROR api-gateway/tests/test_negotiate_response.py
ERROR api-gateway/tests/test_vision.py
```

A failure with no connection to anything under test, in a PR that touched neither the gateway nor its dependencies.

## The change

```diff
-	PYTHONPATH=$(GATEWAY_PATH) uv run pytest api-gateway/tests/ -v
+	uv sync --package api-gateway --inexact
+	PYTHONPATH=$(GATEWAY_PATH) uv run --no-sync pytest api-gateway/tests/ -v
```

The gateway's test env becomes its own declarations, the way the `mcp-server` and `aura-worker` blocks already work. `--inexact` adds to what is already synced rather than pruning it; `--no-sync` stops `uv run` from reverting the additive install.

## Verification

On a root env with `python-multipart` removed — i.e. the world #286 creates:

| | gateway test block |
|---|---|
| before | 2 collection errors |
| after | `+ python-multipart==0.0.32`, 7 passed |

`make lint` and `make test` green end to end from a pruned `uv sync --group dev` starting point.

## Still open, deliberately not in this PR

`core`, `synapses/telegram-bot` and `agents/bee-keeper` are workspace members too, and their test blocks still run against the root env. The root's dependency list mirrors theirs by hand (`dspy-ai`, `sqlalchemy`, `aiogram` in the dev group…), so the same class of accident can happen again with any dependency one of them adds and the root does not. Worth the same treatment, but each needs its own check that syncing the package doesn't drag in something heavy — bee-keeper's dspy stack in particular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)