### PR TITLE
fix(docker): let the buf download fail loudly instead of writing an error page

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     BUF_VERSION="1.47.2" && \
-    curl -sSL "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64" -o "/usr/local/bin/buf" && \
+    curl -fsSL --retry 3 --retry-delay 2 \
+        "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64" \
+        -o "/usr/local/bin/buf" && \
     chmod +x "/usr/local/bin/buf" && \
     rm -rf /var/lib/apt/lists/*
 

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -5,13 +5,17 @@ WORKDIR /app
 # Install system dependencies for health probe and health checks
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
-    curl -fsSL -o /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.44/grpc_health_probe-linux-amd64 && \
+    curl -fsSL --retry 3 --retry-delay 2 \
+        -o /bin/grpc_health_probe \
+        https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.44/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe && \
     rm -rf /var/lib/apt/lists/*
 
 # Install buf
 RUN BUF_VERSION="1.47.2" && \
-    curl -sSL "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64" -o "/usr/local/bin/buf" && \
+    curl -fsSL --retry 3 --retry-delay 2 \
+        "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64" \
+        -o "/usr/local/bin/buf" && \
     chmod +x "/usr/local/bin/buf"
 
 ENV UV_COMPILE_BYTECODE=1

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 # Install buf
 RUN apk add --no-cache curl && \
     BUF_VERSION="1.47.2" && \
-    curl -sSL "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64" -o "/usr/local/bin/buf" && \
+    curl -fsSL --retry 3 --retry-delay 2 \
+        "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64" \
+        -o "/usr/local/bin/buf" && \
     chmod +x "/usr/local/bin/buf"
 
 # Copy workspace files for buf


### PR DESCRIPTION
Fourth of four. The one that has been quietly costing CI runs all along.

## The defect

Three Dockerfiles fetched the `buf` binary with `curl -sSL`. Without `-f`, curl treats an HTTP error response as a **successful transfer**: it exits 0 and writes the error body to the output path. The next line `chmod +x`es that HTML and the build carries on, until several steps later:

```
/usr/local/bin/buf: 1: Syntax error: redirection unexpected
ERROR: process "/bin/sh -c buf generate" did not complete successfully: exit code: 2
```

An error that names neither curl, nor the download, nor the fact that a network request failed.

This is not hypothetical — GitHub Releases returned 503s during today's CI, and that one missing flag turned it into **three red jobs across three PRs** (#285 api-gateway, #286 frontend, and a rerun), each reporting a shell syntax error inside a binary.

## Measured

Against a local server returning 503:

| command | exit | output path |
|---|---|---|
| `curl -sSL -o buf` | **0** | 65 bytes of HTML |
| `curl -fsSL -o buf` | **22** | no file written |

## The change

`curl -sSL` → `curl -fsSL --retry 3 --retry-delay 2` in:

- `core/Dockerfile` (buf)
- `api-gateway/Dockerfile` (buf)
- `frontend/Dockerfile` (buf)

The retries go with `-f` deliberately: 503 is exactly the transient class curl retries, and an honest failure against a flaky mirror is still a red build. `-f` makes the failure truthful; `--retry` makes it rare.

`core/Dockerfile`'s `grpc_health_probe` fetch already had `-f` — it is the one that failed *correctly* today (`curl: (22) ... error: 503`) — so it gains only the retries.

## Verification

All three images build clean locally with the fix — `api-gateway`, `core`, `frontend`, exit 0 each. In the built core image:

```
-rwxr-xr-x 1 root root 13437134 /bin/grpc_health_probe
0000000 177   E   L   F
```

A real ELF binary, not an error page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)