### PR TITLE
fix(worker): survive a dropped connection while fetching frpc

### DIFF
--- a/packages/aura-worker/src/aura_worker/tunnel.py
+++ b/packages/aura-worker/src/aura_worker/tunnel.py
@@ -22,6 +22,11 @@ class Umbilical:
     FRPC_SHA256: str = (
         "720a9fe2a3299346572544909a78c023344c88bde13c55b921e298e8c5ded21f"
     )
+    FRPC_DOWNLOAD_ATTEMPTS: int = 3
+
+    # What curl calls a transient error, and what a release CDN actually does
+    # under load. Anything else is a verdict, not a blip.
+    _RETRIABLE_STATUS: frozenset[int] = frozenset({408, 429, 500, 502, 503, 504})
 
     def __init__(
         self,
@@ -47,6 +52,55 @@ class Umbilical:
 
         self.process: asyncio.subprocess.Process | None = None
 
+    def _is_transient(self, exc: httpx.HTTPError) -> bool:
+        if isinstance(exc, httpx.TransportError):
+            return True
+        if isinstance(exc, httpx.HTTPStatusError):
+            return exc.response.status_code in self._RETRIABLE_STATUS
+        return False
+
+    async def _fetch_frpc_archive(self, url: str, dest: Path) -> str:
+        """Stream the archive to dest, returning its hex digest.
+
+        A single dropped connection used to end the worker's whole run: the
+        release CDN closed the socket without a response, and the traceback said
+        only "Server disconnected", naming neither the file nor where it came
+        from. Blips get another go; a 404 or a bad gateway-less error does not.
+        """
+        for attempt in range(1, self.FRPC_DOWNLOAD_ATTEMPTS + 1):
+            sha256 = hashlib.sha256()
+            try:
+                async with httpx.AsyncClient(follow_redirects=True) as client:
+                    async with client.stream("GET", url, timeout=60.0) as response:
+                        response.raise_for_status()
+                        async with aiofiles.open(dest, "wb") as f:
+                            async for chunk in response.aiter_bytes(chunk_size=8192):
+                                await f.write(chunk)
+                                sha256.update(chunk)
+            except httpx.HTTPError as exc:
+                dest.unlink(missing_ok=True)
+                if not self._is_transient(exc):
+                    raise
+                if attempt == self.FRPC_DOWNLOAD_ATTEMPTS:
+                    raise RuntimeError(
+                        f"Could not download frpc from {url} after "
+                        f"{self.FRPC_DOWNLOAD_ATTEMPTS} attempts: {exc}"
+                    ) from exc
+
+                delay = 2**attempt
+                logger.warning(
+                    "frpc download failed, retrying",
+                    attempt=attempt,
+                    of=self.FRPC_DOWNLOAD_ATTEMPTS,
+                    retry_in=delay,
+                    error=str(exc),
+                )
+                await asyncio.sleep(delay)
+            else:
+                return sha256.hexdigest()
+
+        raise AssertionError("unreachable: the loop either returns or raises")
+
     async def ensure_frpc(self) -> None:
         if self.frpc_path.exists():
             return
@@ -60,20 +114,12 @@ class Umbilical:
         logger.info("Downloading frpc", version=self.FRPC_VERSION)
 
         tar_path: Path = self.bin_dir / frp_file
-        sha256 = hashlib.sha256()
+        digest: str = await self._fetch_frpc_archive(frp_url, tar_path)
 
-        async with httpx.AsyncClient(follow_redirects=True) as client:
-            async with client.stream("GET", frp_url, timeout=60.0) as response:
-                response.raise_for_status()
-                async with aiofiles.open(tar_path, "wb") as f:
-                    async for chunk in response.aiter_bytes(chunk_size=8192):
-                        await f.write(chunk)
-                        sha256.update(chunk)
-
-        if sha256.hexdigest() != self.FRPC_SHA256:
+        if digest != self.FRPC_SHA256:
             tar_path.unlink()
             raise RuntimeError(
-                f"Checksum verification failed for frpc! Expected {self.FRPC_SHA256}, got {sha256.hexdigest()}"
+                f"Checksum verification failed for frpc! Expected {self.FRPC_SHA256}, got {digest}"
             )
 
         logger.info("Checksum verified. Extracting...")

--- a/packages/aura-worker/tests/test_tunnel.py
+++ b/packages/aura-worker/tests/test_tunnel.py
@@ -4,6 +4,7 @@ Subprocess, HTTP and the real filesystem are avoided via tmp paths + mocks.
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 import toml
 from aura_worker.tunnel import Umbilical
@@ -122,6 +123,114 @@ async def test_ensure_frpc_rejects_bad_checksum(tmp_path):
 
     tar_path = u.bin_dir / f"frp_{u.FRPC_VERSION}_linux_amd64.tar.gz"
     assert not tar_path.exists()  # partial download cleaned up
+
+
+def _scripted_client(*outcomes):
+    """An httpx.AsyncClient stand-in playing one outcome per stream() call.
+
+    An outcome is either an exception — raised on entering the stream, which is
+    where both a dropped connection and a raise_for_status land as far as the
+    caller is concerned — or the bytes the response body should yield.
+
+    Returns the client context manager and the list that records each attempt.
+    """
+    attempts: list[str] = []
+
+    def _stream(method, url, **kwargs):
+        attempts.append(url)
+        outcome = outcomes[len(attempts) - 1]
+        cm = MagicMock()
+        cm.__aexit__ = AsyncMock(return_value=False)
+        if isinstance(outcome, Exception):
+            cm.__aenter__ = AsyncMock(side_effect=outcome)
+            return cm
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+
+        async def _aiter_bytes(chunk_size=8192, _body=outcome):
+            yield _body
+
+        response.aiter_bytes = _aiter_bytes
+        cm.__aenter__ = AsyncMock(return_value=response)
+        return cm
+
+    client = MagicMock()
+    client.stream = MagicMock(side_effect=_stream)
+    client_cm = MagicMock()
+    client_cm.__aenter__ = AsyncMock(return_value=client)
+    client_cm.__aexit__ = AsyncMock(return_value=False)
+    return client_cm, attempts
+
+
+def _dropped_connection():
+    return httpx.RemoteProtocolError("Server disconnected without sending a response.")
+
+
+def _missing_release():
+    request = httpx.Request("GET", "https://github.com/fatedier/frp")
+    return httpx.HTTPStatusError(
+        "404", request=request, response=httpx.Response(404, request=request)
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_frpc_retries_a_dropped_connection(tmp_path):
+    """One blip must not end the download — this is what killed a Colab run."""
+    u = _umbilical(tmp_path)
+    client_cm, attempts = _scripted_client(_dropped_connection(), b"second-attempt")
+
+    with patch("aura_worker.tunnel.httpx.AsyncClient", return_value=client_cm):
+        with patch("aura_worker.tunnel.asyncio.sleep", AsyncMock()):
+            # The retry succeeds at the network layer; the body is not the real
+            # archive, so it stops at the checksum — past the point that failed.
+            with pytest.raises(RuntimeError, match="Checksum verification failed"):
+                await u.ensure_frpc()
+
+    assert len(attempts) == 2
+
+
+@pytest.mark.asyncio
+async def test_ensure_frpc_reports_the_url_when_every_attempt_drops(tmp_path):
+    u = _umbilical(tmp_path)
+    client_cm, attempts = _scripted_client(
+        _dropped_connection(), _dropped_connection(), _dropped_connection()
+    )
+
+    with patch("aura_worker.tunnel.httpx.AsyncClient", return_value=client_cm):
+        with patch("aura_worker.tunnel.asyncio.sleep", AsyncMock()):
+            with pytest.raises(RuntimeError, match="frp_0.61.0_linux_amd64.tar.gz"):
+                await u.ensure_frpc()
+
+    assert len(attempts) == u.FRPC_DOWNLOAD_ATTEMPTS == 3
+
+
+@pytest.mark.asyncio
+async def test_ensure_frpc_does_not_retry_a_missing_release(tmp_path):
+    """A 404 will not heal on its own; retrying it only delays the truth."""
+    u = _umbilical(tmp_path)
+    client_cm, attempts = _scripted_client(_missing_release(), b"never-reached")
+
+    with patch("aura_worker.tunnel.httpx.AsyncClient", return_value=client_cm):
+        with patch("aura_worker.tunnel.asyncio.sleep", AsyncMock()):
+            with pytest.raises(httpx.HTTPStatusError):
+                await u.ensure_frpc()
+
+    assert len(attempts) == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_frpc_does_not_retry_a_bad_checksum(tmp_path):
+    """The integrity check is a verdict, not a transient error."""
+    u = _umbilical(tmp_path)
+    client_cm, attempts = _scripted_client(b"corrupted", b"corrupted")
+
+    with patch("aura_worker.tunnel.httpx.AsyncClient", return_value=client_cm):
+        with patch("aura_worker.tunnel.asyncio.sleep", AsyncMock()):
+            with pytest.raises(RuntimeError, match="Checksum verification failed"):
+                await u.ensure_frpc()
+
+    assert len(attempts) == 1
 
 
 # --- stop -------------------------------------------------------------------


### PR DESCRIPTION
## What happened

A Colab run died mid-flight, right after pulling a 6.6 GB model:

```
2026-08-12 21:59:35 [info] Downloading frpc  version=0.61.0
❌ Cardiac arrest: Server disconnected without sending a response.
```

Under a second, against a 60s timeout. That message is `httpx.RemoteProtocolError`: the connection was **established**, the request went out, and the peer closed it without sending so much as a response header. Not DNS, not a refused connection, not an HTTP error — `raise_for_status()` would have said "503".

## Nothing was wrong with the request

- the URL serves `200` and 12 670 877 bytes, via one redirect to `release-assets.githubusercontent.com`;
- the SHA256 pinned in `tunnel.py` still matches today's asset;
- the same code path, run from the published package, downloads, verifies and installs frpc end to end;
- a probe from the same Colab session succeeded on its **first** attempt.

It was one blip. `ensure_frpc` had no second attempt, so one blip was enough to unwind the whole clinical test — after the model pull, which is the expensive part.

## The change

The download gets `FRPC_DOWNLOAD_ATTEMPTS` (3) tries with 2s/4s backoff, and only for the transient class:

| condition | behaviour |
|---|---|
| transport error (dropped connection, timeout, truncated body) | retry |
| 408, 429, 500, 502, 503, 504 | retry |
| 404 and other 4xx | raise immediately — a missing release does not heal |
| checksum mismatch | raise immediately — an integrity verdict is not a blip |

The retriable set is the same one curl treats as transient, which keeps this consistent with the Dockerfile fetches in #288.

When every attempt drops, the error names the file and the URL rather than just "Server disconnected" — the original message identified neither what was being downloaded nor from where, which is why diagnosing this needed a probe rather than a read.

## Tests

`_scripted_client` plays one outcome per `stream()` call, so a run can be scripted as "drop, then body". Four cases: a dropped connection is retried; exhausting the attempts reports the URL; a 404 is attempted exactly once; a bad checksum is attempted exactly once.

The retry tests fail on the parent commit with the error propagating on attempt 1.

## Verification

- Worker suite 59 → 63; `make lint` and `make test` green.
- The real download still completes through the patched code: 14 913 688 bytes installed, checksum verified, against the live release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)