### PR TITLE
test(make): give core, telegram-bot and bee.Keeper their own test env too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,22 +59,29 @@ keeper-audit: $(PROTO_SENTINEL)
 	# One bee.Keeper cycle, then exit. Without --once main.py is a NATS daemon.
 	PYTHONPATH=$(KEEPER_PATH) uv run python -m aura_keeper.main --once
 
+# Every suite below syncs its own package before running. These are workspace
+# members, not dependencies of the root, so `uv sync --group dev` never reaches
+# what they declare — their tests used to run on whatever the root env happened
+# to carry. That worked by coincidence until it didn't: gradio was quietly
+# supplying api-gateway's python-multipart, and the day gradio became optional
+# two gateway modules died at collection, nowhere near anything under test.
+# --inexact adds each package's deps to what is already synced rather than
+# pruning it; --no-sync then stops `uv run` reverting the additive install.
 test: $(PROTO_SENTINEL)
 	# Run core tests
-	PYTHONPATH=$(CORE_PATH) uv run pytest core/tests/ -v
-	# Run api-gateway tests (env is provided by api-gateway/tests/conftest.py).
-	# Sync the gateway's own declared deps rather than trusting the root env to
-	# happen to carry them: it is a workspace member, not a root dependency, so
-	# `uv sync --group dev` never reaches its declarations, and until something
-	# else stopped pulling python-multipart in nobody could tell. --inexact adds
-	# them to what is already synced; --no-sync stops `uv run` reverting that.
+	uv sync --package core --inexact
+	PYTHONPATH=$(CORE_PATH) uv run --no-sync pytest core/tests/ -v
+	# Run api-gateway tests (env is provided by api-gateway/tests/conftest.py)
 	uv sync --package api-gateway --inexact
 	PYTHONPATH=$(GATEWAY_PATH) uv run --no-sync pytest api-gateway/tests/ -v
 	# Run telegram-bot tests with isolated path to avoid 'src' collision
-	PYTHONPATH=$(TG_PATH) uv run pytest synapses/telegram-bot/tests/ -v
-	# Run bee.Keeper tests from the root env: its transformer imports dspy, which
-	# is declared in the root pyproject rather than the agent's own.
-	PYTHONPATH=$(KEEPER_PATH) uv run pytest agents/bee-keeper/tests/ -v
+	uv sync --package telegram-bot --inexact
+	PYTHONPATH=$(TG_PATH) uv run --no-sync pytest synapses/telegram-bot/tests/ -v
+	# Run bee.Keeper tests. Syncing the agent is not enough on its own: its
+	# transformer imports dspy, which is declared in the root pyproject rather
+	# than the agent's own — --inexact is what keeps that reachable.
+	uv sync --package aura-keeper --inexact
+	PYTHONPATH=$(KEEPER_PATH) uv run --no-sync pytest agents/bee-keeper/tests/ -v
 	# Run bee.Evolver tests in its own env — it deliberately has no aura-core dep.
 	cd agents/bee-evolver && uv run --group dev pytest tests/ -v
 	# Run the aura-core packaging guard: it builds the wheel in place and asserts


### PR DESCRIPTION
Finishes what #287 started. That PR gave api-gateway its own test env after gradio stopped quietly supplying its `python-multipart`; the other three workspace members had the same arrangement and the same exposure.

## The arrangement

`core`, `telegram-bot` and `agents/bee-keeper` are workspace members, not dependencies of the root project. `uv sync --group dev` therefore never reaches what they declare — their tests ran on whatever the root env happened to carry.

## This is the latent case, not the burning one

Nothing is missing today. `uv sync --package <name> --inexact --dry-run` against a freshly synced root env:

| package | would install |
|---|---|
| `core` | `core==0.1.0` — the member itself, no deps |
| `telegram-bot` | nothing |
| `aura-keeper` | `aura-keeper==0.1.0` — the member itself, no deps |

So nothing heavy gets dragged in — bee-keeper's dspy stack in particular already comes from the root. The accident waiting to happen is the *next* dependency any of them adds that the root does not also list by hand.

`telegram-bot` shows the shape of it. It declares `aiogram`; the root carries `aiogram` only in its dev group. Remove that one package and the bot's tests die in `conftest.py`, on an import with no connection to whatever change broke it:

```
ImportError while loading conftest '.../telegram-bot/tests/conftest.py'
    from aiogram import types
E   ModuleNotFoundError: No module named 'aiogram'
```

## The change

Each of the three gets `uv sync --package <name> --inexact` before its run, and `uv run --no-sync` after, matching api-gateway, mcp-server and aura-worker.

The rationale now lives **once** above the target rather than being restated per block — it was on its way to a fourth copy.

bee.Keeper keeps a note of its own, because syncing the agent is not the whole story there: its transformer imports `dspy`, which is declared in the root pyproject rather than the agent's, and `--inexact` is precisely what keeps that reachable.

## Verification

With `aiogram` **and** `python-multipart` uninstalled and no prior `uv sync`, `make test` restores each from the block that declares it and passes end to end:

```
+ python-multipart==0.0.32     ← api-gateway block
+ aiogram==3.30.0              ← telegram-bot block
test exit=0
```

Before the change, the same removal leaves telegram-bot failing at collection. `make lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)